### PR TITLE
remove google api reference and db reference for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Beans is an internal networking tool to help employees connect with each other a
 * [Google App-Engine](https://cloud.google.com/appengine/)
 * [Python2.7](https://www.python.org/download/releases/2.7/)
 * [Flask](http://flask.pocoo.org/)
-* [Google API for emails](https://developers.google.com/gmail/api/)
+* [SendGrid for emails](https://sendgrid.com/)
 * [Ndb data store](https://cloud.google.com/appengine/docs/python/ndb/)
 * [S3 integration](https://aws.amazon.com/s3/)
 * [Blossom algorithm](https://en.wikipedia.org/wiki/Blossom_algorithm)
@@ -34,6 +34,3 @@ Beans is an internal networking tool to help employees connect with each other a
      to add keys for AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
      SENDGRID_API_KEY, and SENDGRID_SENDER
  7. make serve
-
-## Google Appengine Setup
- 1. add datastore secrets: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY

--- a/tests/logic/secret_test.py
+++ b/tests/logic/secret_test.py
@@ -8,15 +8,6 @@ import json
 import pytest
 
 from yelp_beans.logic.secret import get_secret
-from yelp_beans.models import Secret
-
-
-def test_get_secret_database(tmpdir, database):
-    with tmpdir.as_cwd():
-        expected = 'password'
-        Secret(id='secret', value=expected).put()
-        actual = get_secret('secret')
-        assert expected == actual
 
 
 def test_get_secret_file(tmpdir, database):

--- a/yelp_beans/logic/secret.py
+++ b/yelp_beans/logic/secret.py
@@ -12,4 +12,4 @@ def get_secret(id):
         secrets = json.loads(open("client_secrets.json").read())
         return secrets[id]
     else:
-        raise IOError("No secrets file or store in DB.")
+        raise IOError("No secrets file.")


### PR DESCRIPTION
We use sendgrid and we don't want to store secrets in the DB.