### PR TITLE
Makefile be better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ all: development
 .PHONY: production
 production: export VIRTUALENV_REQUIREMENTS = requirements.txt
 production: venv node_modules
-	webpack
+	npm run webpack
 
 .PHONY: development
 development: venv install-hooks js
 
 .PHONY: js
 js: node_modules
-	webpack
+	npm run webpack
 
 .PHONY: test
 test: development install-hooks

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,11 @@ js: node_modules
 
 .PHONY: test
 test: development install-hooks
-	coverage run -m py.test tests/
-	coverage report --show-missing
-	coverage html
-	pre-commit run --all-files
-	check-requirements
+	./venv/bin/coverage run -m py.test tests/
+	./venv/bin/coverage report --show-missing
+	./venv/bin/coverage html
+	./venv/bin/pre-commit run --all-files
+	./venv/bin/check-requirements
 	npm test
 	node_modules/.bin/eslint js/
 

--- a/package.json
+++ b/package.json
@@ -45,9 +45,10 @@
     "imports-loader": "^0.7.0",
     "jquery": "^3.1.1",
     "jsdom": "^9.9.1",
+    "mocha": "^3.2.0",
     "react-addons-test-utils": "^15.4.1",
     "sinon": "^1.17.7",
-    "webpack": "^2.2.0-rc.3",
+    "webpack": "^2.2.1",
     "webpack-dev-server": "^2.2.0-rc.0"
   },
   "babel": {
@@ -60,7 +61,8 @@
   "scripts": {
     "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --port 8001",
     "test": "mocha --compilers js:babel-core/register --require ./tests/test_helper.js --recursive ./tests --inspect",
-    "test:watch": "npm run test -- --watch"
+    "test:watch": "npm run test -- --watch",
+    "webpack": "webpack"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will streamline development environment setup.
* Uses venv binaries so that venv doesn't need to be sourced before running `make`
* Installs and runs webpack and mocha locally, no more `npm install -g` required