### PR TITLE
enhance rule matching options for who is allowed in a subscription

### DIFF
--- a/tests/routes/api/v1/preference_test.py
+++ b/tests/routes/api/v1/preference_test.py
@@ -27,6 +27,7 @@ def test_preferences_api_user_exists(app, database, fake_user):
             'office': 'USA: CA SF New Montgomery Office',
             'timezone': 'US/Pacific',
             'size': 2,
+            'rule_logic': None,
             'datetime': [
                 {
                     'active': True,

--- a/yelp_beans/models.py
+++ b/yelp_beans/models.py
@@ -49,6 +49,7 @@ class MeetingSubscription(ndb.Model):
     timezone = ndb.StringProperty()
     user_list = ndb.KeyProperty(kind="User", repeated=True)
     rules = ndb.KeyProperty(kind="Rule", repeated=True)
+    rule_logic = ndb.StringProperty()
 
 
 class Rule(ndb.Model):


### PR DESCRIPTION
ran `make test`

This enhances functionality for rules.  

In the past, a subscription would require a rule.  In simple cases there may not need to be a rule and having rules adds to the complexity of setup.  For example, you may want everyone in your org to be able to see the subscription no matter what.

In advanced cases, you may have a group of rules that need to be met or one rule in that group that needs to be met.  For example, you want to have people in a department <b>and</b> in a building see the subscription or your want people in a department <b>or</b> a building see the subscription.

This PR solves the none, any, and all rule combinations for subscription setup.

This is currently in production on Yelp's internal production instance.