### PR TITLE
Send emails to users with localized timezone

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ FAKE_USER = [{
         'srv0/yelp_large_assets/3f74899c069c'
         '/assets/img/illustrations/mascots/darwin@2x.png'
     ),
+    'timezone': 'America/Los_Angeles',
     'department': 'Consumer',
     'business_title': 'Engineer',
 }]
@@ -229,6 +230,7 @@ def _fake_user():
                 'office': 'USA: CA SF New Montgomery Office',
                 'company_profile_url': 'https://www.yelp.com/user_details?userid=nkN_do3fJ9xekchVC-v68A',
             },
+            timezone=user['timezone'],
             subscription_preferences=[preferences],
         )
         user_entity.put()

--- a/tests/logic/meeting_spec_test.py
+++ b/tests/logic/meeting_spec_test.py
@@ -14,3 +14,22 @@ def test_get_users_from_spec(database, fake_user):
 
 def test_get_meeting_datetime(database, subscription):
     assert get_meeting_datetime(database.specs[0]).hour == 15
+
+
+def test_get_meeting_datetime_user_timezone(database, fake_user):
+    fake_user.timezone = 'America/Edmonton'
+    meeting_time = get_meeting_datetime(database.specs[0], fake_user)
+
+    assert meeting_time.tzinfo.zone == fake_user.timezone, (
+        "The meeting time should be in the user's timezone"
+    )
+
+
+def test_get_meeting_datetime_user_no_timezone(database, fake_user):
+    fake_user.timezone = None
+    localtime = get_meeting_datetime(database.specs[0], fake_user)
+
+    meeting_spec_timezone = database.specs[0].meeting_subscription.get().timezone
+    assert localtime.tzinfo.zone == meeting_spec_timezone, (
+        'User has no timezone, the meeting timezone should default to the meeting spec'
+    )

--- a/yelp_beans/logic/meeting_spec.py
+++ b/yelp_beans/logic/meeting_spec.py
@@ -55,7 +55,14 @@ def get_users_from_spec(meeting_spec):
     return users
 
 
-def get_meeting_datetime(meeting_spec):
+def get_meeting_datetime(meeting_spec, user=None):
+    ''' Get the meeting datetime for user. If user is specified, the timezone will be the user's
+    timezone preference. If not specified, the timezone will be the meeting spec's timezone.
+    '''
+    if user and user.timezone:
+        meeting_timezone = user.timezone
+    else:
+        meeting_timezone = meeting_spec.meeting_subscription.get().timezone
+
     meeting_datetime = meeting_spec.datetime
-    meeting_timezone = meeting_spec.meeting_subscription.get().timezone
     return meeting_datetime.replace(tzinfo=utc).astimezone(timezone(meeting_timezone))

--- a/yelp_beans/models.py
+++ b/yelp_beans/models.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from google.appengine.ext import ndb
+from pytz import common_timezones
 
 
 class User(ndb.Model):
@@ -20,6 +21,7 @@ class User(ndb.Model):
     last_name = ndb.StringProperty(indexed=False)
     photo_url = ndb.TextProperty()
     metadata = ndb.JsonProperty()
+    timezone = ndb.StringProperty(default='America/Los_Angeles', choices=common_timezones, required=True)
     terminated = ndb.BooleanProperty(default=False, required=True)
     subscription_preferences = ndb.KeyProperty(
         kind="UserSubscriptionPreferences",

--- a/yelp_beans/send_email.py
+++ b/yelp_beans/send_email.py
@@ -10,7 +10,6 @@ import urllib
 
 from jinja2 import Environment
 from jinja2 import PackageLoader
-from pytz import timezone
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers import mail
 from sendgrid.helpers.mail import Content
@@ -88,10 +87,7 @@ def send_batch_weekly_opt_in_email(meeting_spec):
 
     for user in users:
         if not user.terminated:
-            if user.timezone:
-                tz = timezone(user.timezone)
-                meeting_localdatetime = meeting_datetime.astimezone(tz)
-
+            meeting_localdatetime = get_meeting_datetime(meeting_spec, user)
             logging.info(user)
             logging.info(meeting_localdatetime)
             send_single_email(
@@ -134,12 +130,7 @@ def send_match_email(user, participants, meeting_spec):
         participants - other people in the meeting
         meeting_spec - meeting specification
     """
-    meeting_datetime = get_meeting_datetime(meeting_spec)
-
-    if user.timezone:
-        tz = timezone(user.timezone)
-        meeting_datetime = meeting_datetime.astimezone(tz)
-
+    meeting_datetime = get_meeting_datetime(meeting_spec, user)
     meeting_datetime_end = meeting_datetime + datetime.timedelta(minutes=30)
     subscription = meeting_spec.meeting_subscription.get()
 


### PR DESCRIPTION
This adds support for sending emails to user's with localized timezone. Currently user timezone information does not exist so this change should not result in visible changes.

This still needs an end-to-end test but I'm unsure how to do this:
* Send test email to ensure timezone works
* Do dataprovider sync to test the model change.