### PR TITLE
Removed some unused deps and replaced usage of lodash with Object.assign

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,4 @@
 {
-  "presets": [
-      "es2015",
-      "stage-2",
-      "react"
-  ]
+  "presets": [ "es2015", "react" ],
+  "plugins": ["transform-object-assign"]
 }

--- a/js/components/UserPreferenceForm.jsx
+++ b/js/components/UserPreferenceForm.jsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
@@ -37,7 +36,7 @@ class UserPreferenceForm extends Component {
         [event.target.id]: event.target.checked,
       },
     };
-    this.setState(_.merge({}, this.state, data));
+    this.setState(Object.assign({}, this.state, data));
   }
   renderPreferences(state) {
     if (this.props.preferences.length !== 0) {

--- a/package.json
+++ b/package.json
@@ -8,14 +8,7 @@
   },
   "dependencies": {
     "axios": "^0.15.3",
-    "classnames": "^2.2.1",
-    "invariant": "^2.2.0",
-    "jsx-loader": "^0.13.2",
-    "keymirror": "^0.1.1",
-    "lodash": "^4.17.4",
-    "moment": "^2.17.1",
     "moment-timezone": "^0.5.11",
-    "path": "^0.12.7",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-router": "^3.0.0",
@@ -27,21 +20,18 @@
   "devDependencies": {
     "axios-mock-adapter": "^1.7.1",
     "babel-core": "^6.18.2",
-    "babel-jest": "18.0.0",
     "babel-loader": "^6.2.7",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
     "chai": "^3.5.0",
     "chai-jquery": "^2.0.0",
-    "enzyme": "^2.7.0",
     "eslint": "^3.14.1",
     "eslint-config-airbnb": "^14.0.0",
     "eslint-loader": "^1.6.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-react": "^6.9.0",
-    "fbjs": "^0.8.5",
     "imports-loader": "^0.7.0",
     "jquery": "^3.1.1",
     "jsdom": "^9.9.1",
@@ -50,13 +40,6 @@
     "sinon": "^1.17.7",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.2.0-rc.0"
-  },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-0",
-      "react"
-    ]
   },
   "scripts": {
     "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --port 8001",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,14 +20,14 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.jsx?$/,
         loader: 'eslint-loader?{fix: true}',
+        test: /\.jsx?$/,
         exclude: /node_modules/,
         enforce: 'pre',
       },
       {
         use: 'babel-loader',
-        test: /\.(js|jsx)$/,
+        test: /\.jsx?$/,
         exclude: /node_modules/,
       },
     ],


### PR DESCRIPTION
- Removed some deps from `package.json` that I think were unused. `npm run webpack` still succeeds, and `npm test` is still good.

- Removed `lodash` because the only thing it was being used for was `_.merge`. We could theoretically replace that with [`lodash.merge`](https://www.npmjs.com/package/lodash.merge) (so we don't bundle the entire lodash library), but there is a native `Object.assign` that does what we need I think? Had to add a Babel plugin to transpile this because it's not included in the `es2015` Babel preset.