### PR TITLE
Mock axios in index.spec.js to remove node warnings

### DIFF
--- a/js/components/MetricsListItem.jsx
+++ b/js/components/MetricsListItem.jsx
@@ -10,10 +10,10 @@ const MetricsListItem = ({ metric }) => {
       <div className="panel-heading">{metric.title}</div>
       <ul className="list-group">
         <li className="list-group-item">
-                      Total Subscribed: {metric.subscribed}
+          Total Subscribed: {metric.subscribed}
         </li>
         <li className="list-group-item">
-                      Total Meetings: {metric.meetings}
+          Total Meetings: {metric.meetings}
         </li>
       </ul>
     </div>

--- a/tests/js/actions/index.spec.js
+++ b/tests/js/actions/index.spec.js
@@ -1,27 +1,59 @@
 /* eslint-env mocha */
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
-import { FETCH_METRICS, getMetrics } from '../../../js/actions/index';
 
+import {
+  FETCH_METRICS,
+  FETCH_PREFS,
+  FETCH_USER,
+  getMetrics,
+  getPreferences,
+  getUser,
+} from '../../../js/actions/index';
 
 describe('actions', () => {
-  describe('getMetric', () => {
-    it('has the correct type', () => {
-      const metrics = getMetrics('v1');
-      expect(metrics.type).to.equal(FETCH_METRICS);
+  let mockAxios;
+
+  before(() => {
+    mockAxios = new MockAdapter(axios);
+  });
+
+  after(() => {
+    mockAxios.restore();
+  });
+
+  it('getMetric has the correct type', () => {
+    mockAxios.onGet('/v1/metrics/').reply(200);
+    const metrics = getMetrics('v1');
+    expect(metrics.type).to.equal(FETCH_METRICS);
+  });
+
+  describe('getPreferences has the correct type', () => {
+    it('email is undefined', () => {
+      mockAxios.onGet('/v1/user/preferences/').reply(200);
+      const metrics = getPreferences();
+      expect(metrics.type).to.equal(FETCH_PREFS);
+    });
+
+    it('email is defined', () => {
+      mockAxios.onGet('/v1/user/preferences/?email=foo@bar.com').reply(200);
+      const metrics = getPreferences('foo@bar.com');
+      expect(metrics.type).to.equal(FETCH_PREFS);
     });
   });
 
-  describe('getPreferences', () => {
-    it('has the correct type', () => {
-      const metrics = getMetrics('v1');
-      expect(metrics.type).to.equal(FETCH_METRICS);
+  describe('getUser has the correct type', () => {
+    it('email is undefined', () => {
+      mockAxios.onGet('/v1/user/').reply(200);
+      const metrics = getUser('');
+      expect(metrics.type).to.equal(FETCH_USER);
     });
-  });
 
-  describe('getUser', () => {
-    it('has the correct type', () => {
-      const metrics = getMetrics('v1');
-      expect(metrics.type).to.equal(FETCH_METRICS);
+    it('email is defined', () => {
+      mockAxios.onGet('/v1/user/?email=foo@bar.com').reply(200);
+      const metrics = getUser('foo@bar.com');
+      expect(metrics.type).to.equal(FETCH_USER);
     });
   });
 });

--- a/tests/js/components/MetricsListItem.spec.js
+++ b/tests/js/components/MetricsListItem.spec.js
@@ -9,11 +9,8 @@ describe('MetricsListItem', () => {
   let component;
 
   describe('without data', () => {
-    beforeEach(() => {
-      component = renderComponent(MetricsListItem);
-    });
-
     it('prints malformatted if no data', () => {
+      component = renderComponent(MetricsListItem);
       expect(component).to.contain('Malformatted');
     });
   });


### PR DESCRIPTION
This PR fixes #40.
- Mock `axios` in `tests/js/actions/index.spec.js` to remove node warnings.
- Actually test `getPreferences` and `getUser` in the test.