### PR TITLE
Some minor cleanup in Makefile, package.json, & .eslintrc.js.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
     'extends': 'airbnb',
-    'globals': {
-        'document': true
+    'env': {
+        'browser': true
     }
 };

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ coverage-html/
 dist/
 index.yaml
 node_modules/
+npm-debug.log
 tests/.cache
 venv
 yelp_beans.egg-info/

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "react-router": "^3.0.0",
     "react-redux": "^5.0.1",
     "redux": "^3.6.0",
-    "redux-form": "^6.4.3",
     "redux-promise": "^0.5.3"
   },
   "devDependencies": {
@@ -34,9 +33,10 @@
     "webpack-dev-server": "^2.2.0-rc.0"
   },
   "scripts": {
+    "eslint": "eslint --ext .js --ext .jsx .",
     "test": "jest --config .jestrc.json",
-    "test:watch": "jest --watch --config .jestrc.json",
-    "start": "node ./node_modules/webpack-dev-server/bin/webpack-dev-server.js --port 8001",
+    "test:watch": "npm test -- --watch",
+    "webpack-dev-server": "webpack-dev-server --port 8001",
     "webpack": "webpack"
   },
   "repository": {

--- a/tests/js/components/MetricsListItem.spec.jsx
+++ b/tests/js/components/MetricsListItem.spec.jsx
@@ -5,19 +5,19 @@ import MetricsListItem from '../../../js/components/MetricsListItem';
 
 describe('MetricsListItem', () => {
   it('is rendered without data', () => {
-    const component = renderer.create(<MetricsListItem/>);
+    const component = renderer.create(<MetricsListItem />);
     expect(component.toJSON()).toMatchSnapshot();
   });
 
   it('is rendered with one subscription', () => {
-    const metric = {title: 'weekly', subscribed: 10, meetings: 20};
-    const component = renderer.create(<MetricsListItem metric={metric}/>);
+    const metric = { title: 'weekly', subscribed: 10, meetings: 20 };
+    const component = renderer.create(<MetricsListItem metric={metric} />);
     expect(component.toJSON()).toMatchSnapshot();
   });
 
   it('is rendered with many subscriptions', () => {
-    const metric = {title: 'monthly', subscribed: 2, meetings: 4};
-    const component = renderer.create(<MetricsListItem metric={metric}/>);
+    const metric = { title: 'monthly', subscribed: 2, meetings: 4 };
+    const component = renderer.create(<MetricsListItem metric={metric} />);
     expect(component.toJSON()).toMatchSnapshot();
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,6 @@ const VENDOR = [
   'moment-timezone',
   'react',
   'react-dom',
-  'redux-form',
   'react-redux',
   'react-router',
   'redux',


### PR DESCRIPTION
- rearranged some `make` targets 
- renamed `start` npm script to `webpack-dev-server`
- added a new `eslint` npm run script that checks both `.js` and `.jsx` files
- use the `browser` env instead of whitelisting a `document` global
- removed the unused `redux-form` dependency