### PR TITLE
Add CommonsChunkPlugin, and move some vendor libs to the vendor bundle.

### DIFF
--- a/js/components/UserPreferenceForm.jsx
+++ b/js/components/UserPreferenceForm.jsx
@@ -46,10 +46,9 @@ class UserPreferenceForm extends Component {
           <h6>{preference.office}, {preference.location} ({preference.size})</h6>
           <form onSubmit={event => this.handleSubmit(preference.id, event)}>
             { this.renderTimes(preference, state) }
-            <button
-              type="submit"
-              className="btn btn-danger left30"
-            >Set Preferences!</button>
+            <button type="submit" className="btn btn-danger left30">
+              Set Preferences!
+            </button>
           </form>
         </div>
       ));

--- a/js/containers/MeetingRequest.jsx
+++ b/js/containers/MeetingRequest.jsx
@@ -8,17 +8,15 @@ class MeetingRequest extends Component {
   static renderButton(meetingRequest) {
     if (meetingRequest.key === '') {
       return (
-        <button
-          type="submit"
-          className="btn btn-success btn-lg left30"
-        >Ask for a Meeting this week.</button>
+        <button type="submit" className="btn btn-success btn-lg left30">
+          Ask for a Meeting this week.
+        </button>
       );
     }
     return (
-      <button
-        type="submit"
-        className="btn btn-danger btn-lg left30"
-      >Remove request for a Meeting this week.</button>
+      <button type="submit" className="btn btn-danger btn-lg left30">
+        Remove request for a Meeting this week.
+      </button>
     );
   }
   constructor(props) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,14 @@
+const webpack = require('webpack');
+
 const VENDOR = [
   'axios',
+  'moment-timezone',
   'react',
-  'react-router',
   'react-dom',
   'redux-form',
+  'react-redux',
+  'react-router',
+  'redux',
   'redux-promise',
 ];
 
@@ -20,7 +25,7 @@ module.exports = {
   module: {
     rules: [
       {
-        loader: 'eslint-loader?{fix: true}',
+        use: 'eslint-loader?{fix: true}',
         test: /\.jsx?$/,
         exclude: /node_modules/,
         enforce: 'pre',
@@ -39,4 +44,10 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.jsx'],
   },
+  plugins: [
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'vendor',
+      minChunks: Infinity,
+    }),
+  ],
 };


### PR DESCRIPTION
We're currently bundling certain vendor libraries in **both** the app bundle, **and** the vendor bundle. All libraries listed in `VENDOR` in `webpack.config.js` (and their deps presumably) are being bundled twice. Additionally, we're bundling `moment-timezone`, `moment`, `redux`, and `react-redux` in the app bundle, instead of the vendor bundle. Here's what this diff does:

1. Adds the [CommonsChunkPlugin](https://webpack.js.org/plugins/commons-chunk-plugin/#explicit-vendor-chunk) to ensure we only bundle vendor libs once.
2. Adds `moment-timezone`, `redux`, and `react-redux` to the `VENDOR` list, so they are bundled in the vendor bundle, not the app bundle.

Before:
```
(venv) MacBook-Pro:beans adityavohra7$ npm run webpack

> yelp-beans@1.0.0 webpack /Users/adityavohra7/Documents/beans
> webpack

Hash: 5757de382e56a45135ea
Version: webpack 2.2.1
Time: 9909ms
                           Asset     Size  Chunks                    Chunk Names
       dist/bundle/app.bundle.js  1.73 MB       1  [emitted]  [big]  app
    dist/bundle/vendor.bundle.js  1.41 MB       0  [emitted]  [big]  vendor
   dist/bundle/app.bundle.js.map  2.02 MB       1  [emitted]         app
dist/bundle/vendor.bundle.js.map  1.56 MB       0  [emitted]         vendor
   [5] ./~/react/react.js 56 bytes {0} {1} [built]
  [30] ./~/react-redux/es/index.js 194 bytes {0} {1} [built]
  [53] ./~/redux/es/index.js 1.08 kB {0} {1} [built]
  [88] ./~/react-router/es/index.js 1.46 kB {0} {1} [built]
 [143] ./~/axios/index.js 40 bytes {0} {1} [built]
 [144] ./~/react-dom/index.js 59 bytes {0} {1} [built]
 [145] ./~/redux-promise/lib/index.js 1.07 kB {0} {1} [built]
 [478] ./js/reducers/index.js 816 bytes {1} [built]
 [479] ./js/routes.jsx 1.25 kB {1} [built]
 [480] ./~/redux-form/es/index.js 2.96 kB {0} [built]
 [481] ./js/App.jsx 777 bytes {1} [built]
 [493] ./js/reducers/user.js 782 bytes {1} [built]
 [603] ./~/redux-form/es/createAll.js 2.76 kB {0} [built]
 [636] ./js/index.jsx 1.06 kB {1} [built]
 [637] multi axios react react-router react-dom redux-form redux-promise 88 bytes {0} [built]
    + 623 hidden modules
```

After:
```
(venv) MacBook-Pro:beans adityavohra7$ npm run webpack

> yelp-beans@1.0.0 webpack /Users/adityavohra7/Documents/beans
> webpack

Hash: e329d2804b82f28b2ef0
Version: webpack 2.2.1
Time: 8540ms
                           Asset     Size  Chunks                    Chunk Names
       dist/bundle/app.bundle.js  35.3 kB       0  [emitted]         app
    dist/bundle/vendor.bundle.js  2.07 MB       1  [emitted]  [big]  vendor
   dist/bundle/app.bundle.js.map  28.8 kB       0  [emitted]         app
dist/bundle/vendor.bundle.js.map  2.36 MB       1  [emitted]         vendor
   [2] ./~/react/react.js 56 bytes {1} [built]
  [10] ./~/react-redux/es/index.js 194 bytes {1} [built]
  [27] ./~/redux/es/index.js 1.08 kB {1} [built]
  [48] ./~/react-router/es/index.js 1.46 kB {1} [built]
  [68] ./~/axios/index.js 40 bytes {1} [built]
  [69] ./~/react-dom/index.js 59 bytes {1} [built]
  [70] ./~/redux-promise/lib/index.js 1.07 kB {1} [built]
 [122] ./~/moment-timezone/index.js 114 bytes {1} [built]
 [320] ./js/reducers/index.js 816 bytes {0} [built]
 [321] ./js/routes.jsx 1.25 kB {0} [built]
 [322] ./~/redux-form/es/index.js 2.96 kB {1} [built]
 [575] ./~/react-router/es/withRouter.js 2.04 kB {1} [built]
 [631] ./~/redux/es/combineReducers.js 5.58 kB {1} [built]
 [636] ./js/index.jsx 1.06 kB {0} [built]
 [637] multi axios moment-timezone react react-dom redux-form react-redux react-router redux redux-promise 124 bytes {1} [built]
    + 623 hidden modules
```

Things to note:
1. The size of `dist/bundle/app.bundle.js` **decreased** from 1.73 MB to 35.3 kB. This is because we're no longer bundling any vendor libs in this bundle.
2. The size of `dist/bundle/vendor.bundle.js` **increased** from 1.41 MB to 2.07 MB. This is because we're now including certain vendor libs that were previously being bundled in the app bundle.

All in all, net reduction in JS downloaded = (old_app + old_vendor) - (new_app + new_vendor) = (1.73 MB + 1.41 MB) - (35.3kB + 2.07 MB) = ~ 1.03 MB