### PR TITLE
Added webpack-visualizer-plugin to webpack.config.js to visualize JS bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "jest": "^19.0.2",
     "react-test-renderer": "^15.4.2",
     "webpack": "^2.2.1",
-    "webpack-dev-server": "^2.2.0-rc.0"
+    "webpack-dev-server": "^2.2.0-rc.0",
+    "webpack-visualizer-plugin": "^0.1.11"
   },
   "scripts": {
     "eslint": "eslint --ext .js --ext .jsx .",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const webpackVisualizer = require('webpack-visualizer-plugin');
 
 const VENDOR = [
   'axios',
@@ -47,6 +48,9 @@ module.exports = {
     new webpack.optimize.CommonsChunkPlugin({
       name: 'vendor',
       minChunks: Infinity,
+    }),
+    new webpackVisualizer({
+      filename: './dist/webpack.stats.html',
     }),
   ],
 };


### PR DESCRIPTION
Steps to visualize the `Yelp/beans` JS bundles:

1. Run `npm run webpack`. This creates a `dist/webpack.stats.html`.
2. Open `dist/webpack.stats.html` in a browser.

This tool is super helpful to know the split of Webpack JS bundles. This is basically how I found that we were [bundling certain 3rd party libs twice](https://github.com/Yelp/beans/pull/72). And given that adding this plugin doesn't add anything significant to the Webpack compilation time, I think it's okay to always use it? What do y'all think?