### PR TITLE
Add minification to prod Webpack build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ index.yaml
 node_modules/
 npm-debug.log
 tests/.cache
+touch.webpack.*
 venv
 yelp_beans.egg-info/

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "webpack-visualizer-plugin": "^0.1.11"
   },
   "scripts": {
-    "eslint": "eslint --ext .js --ext .jsx .",
-    "test": "jest --config .jestrc.json",
-    "test:watch": "npm test -- --watch",
     "webpack-dev-server": "webpack-dev-server --port 8001",
-    "webpack": "webpack"
+    "webpack": "webpack --progress --color",
+    "eslint": "eslint --ext .jsx --ext .js .",
+    "test": "jest --config .jestrc.json",
+    "test:watch": "npm test -- --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This fixes #19. 

`make production` now runs `npm run webpack -- -p` (instead of just `npm run webpack`). This runs Uglify to minify bundles:

```
C02RJ7C0G8WN:beans avohra$ make production
npm run webpack -- -p

> yelp-beans@1.0.0 webpack /Users/avohra/Documents/services/beans
> webpack --progress --color "-p"

Hash: c0ebf2cbe4c4d37ecfa6
Version: webpack 2.2.1
Time: 16477ms
                           Asset     Size  Chunks                    Chunk Names
       dist/bundle/app.bundle.js  17.9 kB       0  [emitted]         app
    dist/bundle/vendor.bundle.js   613 kB       1  [emitted]  [big]  vendor
   dist/bundle/app.bundle.js.map  73.8 kB       0  [emitted]         app
dist/bundle/vendor.bundle.js.map  3.84 MB       1  [emitted]         vendor
   [3] ./~/react/react.js 56 bytes {1} [built]
  [16] ./~/react-redux/es/index.js 194 bytes {1} [built]
  [30] ./~/redux/es/index.js 1.08 kB {1} [built]
  [37] ./~/react-router/es/index.js 1.46 kB {1} [built]
  [45] ./~/axios/index.js 40 bytes {1} [built]
  [46] ./~/react-dom/index.js 59 bytes {1} [built]
  [47] ./~/redux-promise/lib/index.js 1.07 kB {1} [built]
  [79] ./~/moment-timezone/index.js 114 bytes {1} [built]
 [244] ./js/reducers/index.js 816 bytes {0} [built]
 [245] ./js/routes.jsx 1.25 kB {0} [built]
 [391] ./~/react-router/es/browserHistory.js 183 bytes {1} [built]
 [395] ./~/react-router/es/hashHistory.js 174 bytes {1} [built]
 [397] ./~/react-router/es/match.js 2.31 kB {1} [built]
 [418] ./js/index.jsx 1.06 kB {0} [built]
 [419] multi axios moment-timezone react react-dom react-redux react-router redux redux-promise 112 bytes {1} [built]
    + 405 hidden modules
touch "touch.webpack.prod"
```
`dist/bundle/app.bundle.js` is 17.9 kB when minified. `dist/bundle/vendor.bundle.js` is 613 kB when minified