### PR TITLE
Stop requesting for jQuery because it isn't used anywhere

### DIFF
--- a/yelp_beans/templates/admin_pages.html
+++ b/yelp_beans/templates/admin_pages.html
@@ -24,7 +24,6 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="/css/style.css"/>
     <link rel='shortcut icon' href='/img/favicon.ico' type='/img/x-icon'/>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7" crossorigin="anonymous"></script>
 </head>
 
 <body>

--- a/yelp_beans/templates/user_pages.html
+++ b/yelp_beans/templates/user_pages.html
@@ -23,7 +23,6 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="/css/style.css"/>
     <link rel='shortcut icon' href='/img/favicon.ico' type='/img/x-icon'/>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js" integrity="sha384-3ceskX3iaEnIogmQchP8opvBy3Mi7Ce34nWjpBIwVTHfGYWQS9jwHDVRnpKKHJg7" crossorigin="anonymous"></script>
 </head>
 
 <body>


### PR DESCRIPTION
jQuery doesn't seem to be used anywhere:
```
C02RJ7C0G8WN:beans avohra$ git grep '\$' | grep '\.js'

Makefile:SOURCES := $(shell find js -name '*.jsx' -o -name '*.js')
Makefile:touch.webpack.%: $(SOURCES) node_modules webpack.config.js .babelrc package.json
js/actions/index.js:  return apiGetRequest(`/${version}/metrics/`, FETCH_METRICS);
js/actions/index.js:  return apiGetRequest(`/v1/user/preferences/?email=${email}`, FETCH_PREFS);
js/actions/index.js:  return apiGetRequest(`/v1/user/?email=${email}`, FETCH_USER);
js/actions/index.js:  return apiPostRequest(`/v1/user/preferences/subscription/${id}`, state, POST_PREFS);
js/actions/index.js:  return apiGetRequest(`/v1/meeting_request/${id}`, GET_REQ);
js/components/UserPreferenceForm.jsx:        } else if (`${preference.id}` in state) {
js/components/UserPreferenceForm.jsx:          checked = state[`${preference.id}`][`${datetime.active}`];
webpack.config.js:        test: /\.jsx?$/,
webpack.config.js:        test: /\.jsx?$/,
```