### PR TITLE
improve metrics

### DIFF
--- a/js/components/MetricsListItem.jsx
+++ b/js/components/MetricsListItem.jsx
@@ -1,24 +1,19 @@
 import React from 'react';
 
 
-const MetricsListItem = ({ metric }) => {
-  if (!metric) {
-    return <div>Malformatted</div>;
-  }
-  return (
-    <div className="panel panel-danger">
-      <div className="panel-heading">{metric.title}</div>
-      <ul className="list-group">
-        <li className="list-group-item">
-          Total Subscribed: {metric.subscribed}
-        </li>
-        <li className="list-group-item">
-          Total Meetings: {metric.meetings}
-        </li>
-      </ul>
-    </div>
+const MetricsListItem = ({ metric }) => (
+  <div className="panel panel-danger">
+    <div className="panel-heading">{metric.title}</div>
+    <ul className="list-group">
+      <li className="list-group-item">
+          Total Subscribed: {metric.total_subscribed}
+      </li>
+      <li className="list-group-item">
+          Participants this week: {metric.week_participants}
+      </li>
+    </ul>
+  </div>
   );
-};
 
 MetricsListItem.propTypes = {
   metric: React.PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types

--- a/tests/logic/metrics_test.py
+++ b/tests/logic/metrics_test.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from yelp_beans.logic.metrics import get_subscribed_users
+from yelp_beans.models import MeetingSubscription
+
+
+def test_get_subscribed_users(database, fake_user):
+    subscribed_users = get_subscribed_users()
+    assert len(subscribed_users) == 1
+    assert subscribed_users[database.sub.key.urlsafe()] == ['darwin@yelp.com']
+
+
+def test_get_subscribed_users_multiple(database, fake_user):
+    subscription2 = MeetingSubscription(title='test1').put()
+    subscribed_users = get_subscribed_users()
+
+    assert len(subscribed_users) == 2
+    assert subscribed_users[subscription2.urlsafe()] == []
+    assert subscribed_users[database.sub.key.urlsafe()] == ['darwin@yelp.com']

--- a/tests/routes/api/v1/metrics_test.py
+++ b/tests/routes/api/v1/metrics_test.py
@@ -15,31 +15,40 @@ def test_get_metrics(app, minimal_database):
         response = metrics_api()
         assert response == '[]'
 
-    MeetingSubscription(title='test1').put()
+    new_subscription = MeetingSubscription(title='test1')
+    new_subscription.put()
 
     with app.test_request_context('/v1/metrics'):
-        response = metrics_api()
-        assert response == json.dumps([{
-            "meetings": 0,
-            "subscribed": 0,
-            "title": "test1",
-        }])
+        response = json.loads(metrics_api())
+        assert response[0]["title"] == new_subscription.title
+        assert response[0]["key"] == new_subscription.key.urlsafe()
+        assert response[0]["week_participants"] == 0
+        assert response[0]["subscribed"] == []
 
 
 def test_get_metrics_multiple(app, database, subscription, fake_user):
     with app.test_request_context('/v1/metrics'):
-        response = metrics_api()
-        assert response == json.dumps([{
-            "meetings": 0,
-            "subscribed": 1,
-            "title": "Yelp Weekly",
-        }])
+        response = json.loads(metrics_api())
+        assert len(response) == 1
+        response = response[0]
+        assert response['key'] == database.sub.key.urlsafe()
+        assert response['subscribed'] == ['darwin@yelp.com']
+        assert response['title'] == database.sub.title
+        assert response['week_participants'] == 1
 
-    MeetingSubscription(title='test1').put()
+    new_subscription = MeetingSubscription(title='test1')
+    new_subscription.put()
 
     with app.test_request_context('/v1/metrics'):
-        response = metrics_api()
-        assert response == json.dumps([
-            {"meetings": 0, "subscribed": 1, "title": "Yelp Weekly"},
-            {"meetings": 0, "subscribed": 0, "title": "test1"}
-        ])
+        response = json.loads(metrics_api())
+        assert len(response) == 2
+
+        assert response[0]['key'] == database.sub.key.urlsafe()
+        assert response[0]['subscribed'] == [fake_user.email]
+        assert response[0]['title'] == database.sub.title
+        assert response[0]['week_participants'] == 1
+
+        assert response[1]['key'] == new_subscription.key.urlsafe()
+        assert response[1]['subscribed'] == []
+        assert response[1]['title'] == new_subscription.title
+        assert response[1]['week_participants'] == 0

--- a/yelp_beans/logic/metrics.py
+++ b/yelp_beans/logic/metrics.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from collections import defaultdict
+
+from yelp_beans.logic.meeting_spec import get_specs_for_current_week
+from yelp_beans.logic.meeting_spec import get_users_from_spec
+from yelp_beans.models import MeetingSubscription
+from yelp_beans.models import User
+
+
+def get_subscribed_users():
+    users = User.query().fetch()
+    subscriptions = MeetingSubscription.query().fetch()
+
+    metrics = defaultdict(set)
+    # creates metrics keys for all subscriptions including ones without users
+    for subscription in subscriptions:
+        metrics[subscription.key.urlsafe()] = []
+
+    # creates metrics keys for all subscriptions that have users with user data
+    for user in users:
+        for preference in user.subscription_preferences:
+            metrics[preference.get().subscription.urlsafe()].append(user.email)
+
+    return metrics
+
+
+def get_current_week_participation():
+    participation = defaultdict(dict)
+
+    for spec in get_specs_for_current_week():
+        participation[spec.meeting_subscription.urlsafe()][spec.key.urlsafe()] = [
+            user.get_username() for user in filter(None, get_users_from_spec(spec))
+        ]
+
+    return participation


### PR DESCRIPTION
Fixes #48.  Subscription counts only unique users now.  In addition, this gives a count for current week participation.  

The logic is cleaned up a bit as well, though this isn't the most efficient way of doing this metric.  In the future, we would probably want to add some fields to the database to eliminate having to query the entire DB for some of these metrics.