### PR TITLE
fixes eslint error

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const webpack = require('webpack');
-const webpackVisualizer = require('webpack-visualizer-plugin');
+const WebpackVisualizer = require('webpack-visualizer-plugin');
 
 const VENDOR = [
   'axios',
@@ -49,7 +49,7 @@ module.exports = {
       name: 'vendor',
       minChunks: Infinity,
     }),
-    new webpackVisualizer({
+    new WebpackVisualizer({
       filename: './dist/webpack.stats.html',
     }),
   ],


### PR DESCRIPTION
`make test` fails due to eslint.

`52:9 error A constructor name should not start with a lowercase letter  new-cap`