### PR TITLE
Add more flexible rules for matching

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def _subscription():
         office='USA: CA SF New Montgomery Office',
         timezone=zone,
         datetime=[preference_1.key, preference_2.key],
-        rules=[rule]
+        user_rules=[rule]
     )
     subscription.put()
     return subscription

--- a/tests/logic/subscription_test.py
+++ b/tests/logic/subscription_test.py
@@ -72,7 +72,7 @@ def test_filter_subscriptions_by_user_data_any(database):
     user.put()
 
     rule = Rule(name="department", value="a").put()
-    database.sub.rules = [rule]
+    database.sub.user_rules = [rule]
     database.sub.rule_logic = 'any'
     database.sub.put()
 
@@ -94,7 +94,7 @@ def test_filter_subscriptions_by_user_data_all(database):
     database.sub.rule_logic = 'all'
     rule1 = Rule(name="department", value="a").put()
     rule2 = Rule(name="location", value="c").put()
-    database.sub.rules = [rule1, rule2]
+    database.sub.user_rules = [rule1, rule2]
     database.sub.put()
 
     preference = UserSubscriptionPreferences(
@@ -125,7 +125,7 @@ def test_filter_subscriptions_by_user_data_all(database):
 
 def test_filter_subscriptions_by_user_data_without_rules(database):
     database.sub.rule_logic = 'all'
-    database.sub.rules = []
+    database.sub.user_rules = []
     database.sub.put()
 
     preference = UserSubscriptionPreferences(
@@ -167,7 +167,7 @@ def test_filter_subscriptions_by_user_data_none(database):
 
 def test_filter_subscriptions_by_user_data_none_when_rules_exist(database):
     rule = Rule(name="department", value="b").put()
-    database.sub.rules = [rule]
+    database.sub.user_rules = [rule]
     database.sub.rule_logic = 'none'
     database.sub.put()
     preference = UserSubscriptionPreferences(

--- a/tests/match_test.py
+++ b/tests/match_test.py
@@ -17,6 +17,7 @@ from yelp_beans.models import MeetingParticipant
 from yelp_beans.models import MeetingRequest
 from yelp_beans.models import MeetingSpec
 from yelp_beans.models import MeetingSubscription
+from yelp_beans.models import Rule
 from yelp_beans.models import SubscriptionDateTime
 from yelp_beans.models import User
 from yelp_beans.models import UserSubscriptionPreferences
@@ -26,6 +27,8 @@ MEETING_COOLDOWN_WEEKS = 10
 
 
 def test_generate_meetings_same_department(minimal_database, subscription):
+    rule = Rule(name='department', value='').put()
+    subscription.dept_rules = [rule]
     preference = subscription.datetime[0]
     user_pref = UserSubscriptionPreferences(preference=preference, subscription=subscription.key).put()
     user1 = User(email='a@yelp.com', metadata={'department': 'dept'}, subscription_preferences=[user_pref])
@@ -41,6 +44,9 @@ def test_generate_meetings_same_department(minimal_database, subscription):
 
 
 def test_generate_meetings_with_history(minimal_database, subscription):
+    rule = Rule(name='department', value='').put()
+    subscription.dept_rules = [rule]
+
     preference = subscription.datetime[0]
     user_pref = UserSubscriptionPreferences(preference=preference, subscription=subscription.key).put()
 

--- a/yelp_beans/logic/subscription.py
+++ b/yelp_beans/logic/subscription.py
@@ -17,7 +17,7 @@ from yelp_beans.models import MeetingSubscription
 def filter_subscriptions_by_user_data(subscriptions, user):
     approved_subscriptions = []
     for subscription in subscriptions:
-        subscription_rules = ndb.Key(urlsafe=subscription['id']).get().rules
+        subscription_rules = ndb.Key(urlsafe=subscription['id']).get().user_rules
 
         if subscription.get('rule_logic') == 'any':
             assert subscription_rules, 'You created logic for rules but don\'t have any rules!'

--- a/yelp_beans/match.py
+++ b/yelp_beans/match.py
@@ -30,14 +30,14 @@ def get_disallowed_meetings(users, prev_meeting_tuples, spec):
     id_to_user = {user.key.id(): user for user in users}
     all_pairs = {pair for pair in itertools.combinations(userids, 2)}
 
-    # users aren't matched if they are on the same team
-    pairs = pairs.union({pair for pair in all_pairs if is_same_team(pair, id_to_user)})
-
+    for rule in spec.meeting_subscription.get().dept_rules:
+        rule = rule.get()
+        pairs = pairs.union({pair for pair in all_pairs if is_same(rule.name, pair, id_to_user)})
     return pairs
 
 
-def is_same_team(match, users):
-    return users[match[0]].metadata['department'] == users[match[1]].metadata['department']
+def is_same(field, match, users):
+    return users[match[0]].metadata[field] == users[match[1]].metadata[field]
 
 
 def save_meetings(matches, spec):

--- a/yelp_beans/models.py
+++ b/yelp_beans/models.py
@@ -39,7 +39,8 @@ class MeetingSubscription(ndb.Model):
             - location:         location of the meetings
             - size:             size of the meetings
             - user_list:        users requested/ have access to join subscription
-            - rules:            rules determine how a subscription is going to show up for a person
+            - user_rules:       rules set for allowing people to see a subscription
+            - dept_rules:       rules set for matching people
     """
     title = ndb.StringProperty()
     datetime = ndb.KeyProperty(kind="SubscriptionDateTime", repeated=True)
@@ -48,7 +49,8 @@ class MeetingSubscription(ndb.Model):
     location = ndb.StringProperty()
     timezone = ndb.StringProperty()
     user_list = ndb.KeyProperty(kind="User", repeated=True)
-    rules = ndb.KeyProperty(kind="Rule", repeated=True)
+    user_rules = ndb.KeyProperty(kind="Rule", repeated=True)
+    dept_rules = ndb.KeyProperty(kind="Rule", repeated=True)
     rule_logic = ndb.StringProperty()
 
 

--- a/yelp_beans/templates/email_templates/match_email.html
+++ b/yelp_beans/templates/email_templates/match_email.html
@@ -19,9 +19,10 @@
                         <img style="border-radius:50%;width:80px" src={{participant.photo_url}}>
                     </td>
                     <td width="30px">
-                        <p><a href="mailto:{{participant.email}}">{{participant.first_name}} {{participant.last_name}}</a>
+                        <p><a href="{{participant.metadata.get('company_profile_url')}}">{{participant.first_name}} {{participant.last_name}}</a>
                         </p>
-                        <p>{{participant.department}}</p>
+                        <p>{{participant.metadata.get('department')}}</p>
+                        <p>{{participant.metadata.get('business_title')}}</p>
                     </td>
                     {% endfor %}
                 </tr>


### PR DESCRIPTION
We had a filter hardcoded in to make sure that people don't match on the same team (https://github.com/Yelp/beans/blob/master/yelp_beans/match.py#L40).  This allows the admin to configure what rules are necessary.

We had a case internally where one team wanted to match with themselves to increase communication.  This ended up with no matches because all possible matches were filtered out due to the above hardcoded rule.

I have overloaded the Rule entity to be able to support this new type of rule.  I am considering whether I should add a new Rule entity type to support this situation.  Would like to feedback on a suggested way forward.  That being said, this is currently working in prod internally. 