### PR TITLE
Make test uses tox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,9 @@ touch.webpack.%: $(SOURCES) node_modules webpack.config.js .babelrc package.json
 
 .PHONY: test
 test: development install-hooks
-	./venv/bin/coverage run -m py.test tests/
-	./venv/bin/coverage report --show-missing
-	./venv/bin/coverage html
-	./venv/bin/pre-commit run --all-files
-	./venv/bin/check-requirements
+	tox
+	# npm test
 	npm run eslint
-	npm test
 
 node_modules: package.json
 	npm install

--- a/requirements-dev-minimal.txt
+++ b/requirements-dev-minimal.txt
@@ -4,3 +4,4 @@ pre-commit
 pytest
 requests-mock
 requirements-tools
+tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,9 +7,11 @@ jsonschema==2.6.0
 mock==2.0.0
 nodeenv==1.1.2
 pbr==1.10.0
+pluggy==0.4.0
 pre-commit==0.13.2
 py==1.4.32
 pytest==3.0.6
 requests-mock==1.3.0
 requirements-tools==1.0.0
+tox==2.7.0
 virtualenv==15.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,13 @@ passenv =
     HOME
     APPENGINE_PATH
 setenv =
-    PYTHONPATH={env:APPENGINE_PATH}:{env:PYTHONPATH:}
+    PYTHONPATH={env:APPENGINE_PATH:/usr/local/google_appengine}:{env:PYTHONPATH:}
     SERVER_SOFTWARE = testing
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
     coverage report --show-missing
+    coverage html
     pre-commit install -f --install-hooks
     pre-commit run --all-files
     check-requirements


### PR DESCRIPTION
The error:  ```No module named google.appengine.ext``` has led me to waste developer hours.  We can use our current tox setup with some slight modifications to ensure that users will not have to deal with this error.

Running npm test shows failing tests and needs to be addressed in #85.