### PR TITLE
remove hardcoded timezone

### DIFF
--- a/js/components/UserPreferenceForm.jsx
+++ b/js/components/UserPreferenceForm.jsx
@@ -6,8 +6,8 @@ import { postPreference } from '../actions/index';
 
 
 class UserPreferenceForm extends Component {
-  static isoDateToString(ISODate) {
-    return moment(ISODate).tz('America/Los_Angeles').format('dddd LT z');
+  static isoDateToString(ISODate, timezone) {
+    return moment(ISODate).tz(timezone).format('dddd LT z');
   }
   constructor(props) {
     super(props);
@@ -71,7 +71,7 @@ class UserPreferenceForm extends Component {
             onChange={this.handleChange}
             value={preference.id}
             type="checkbox"
-          />{UserPreferenceForm.isoDateToString(datetime.date)}</label>
+          />{UserPreferenceForm.isoDateToString(datetime.date, preference.timezone)}</label>
         );
       });
     }
@@ -92,7 +92,10 @@ UserPreferenceForm.propTypes = {
 };
 
 function mapStateToProps(state) {
-  return { datetime: state.datetime };
+  return {
+    datetime: state.datetime,
+    timezone: state.timezone,
+  };
 }
 
 export default connect(mapStateToProps, { postPreference })(UserPreferenceForm);


### PR DESCRIPTION
fixes #22.

Set with "Africa/Abidjan"
<img width="702" alt="screen shot 2017-05-29 at 5 35 36 pm" src="https://cloud.githubusercontent.com/assets/2310975/26564441/a811100a-4495-11e7-9f39-d8f1b2c81147.png">

Also confirmed pytz support:

```
>>> eastern = timezone('America/Los_Angeles')
>>> eastern = timezone('America/Los_Angele')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/kentwills/Documents/yelp-beans/venv/lib/python2.7/site-packages/pytz/__init__.py", line 181, in timezone
    raise UnknownTimeZoneError(zone)
pytz.exceptions.UnknownTimeZoneError: 'America/Los_Angele'
```