### PR TITLE
Created new module for matching. Renamed match.py to pair_match.py

### DIFF
--- a/tests/match_test.py
+++ b/tests/match_test.py
@@ -9,9 +9,9 @@ from datetime import timedelta
 
 from yelp_beans.logic.subscription import get_specs_from_subscription
 from yelp_beans.logic.subscription import store_specs_from_subscription
-from yelp_beans.match import generate_meetings
-from yelp_beans.match import get_previous_meetings
-from yelp_beans.match import save_meetings
+from yelp_beans.matching.pair_match import generate_pair_meetings
+from yelp_beans.matching.pair_match import get_previous_pair_meetings
+from yelp_beans.matching.pair_match import save_pair_meetings
 from yelp_beans.models import Meeting
 from yelp_beans.models import MeetingParticipant
 from yelp_beans.models import MeetingRequest
@@ -38,7 +38,7 @@ def test_generate_meetings_same_department(minimal_database, subscription):
     user_list = [user1, user2]
 
     _, specs = get_specs_from_subscription(subscription)
-    matches, unmatched = generate_meetings(user_list, specs[0])
+    matches, unmatched = generate_pair_meetings(user_list, specs[0])
     assert len(unmatched) == 2
     assert len(matches) == 0
 
@@ -63,7 +63,7 @@ def test_generate_meetings_with_history(minimal_database, subscription):
     week_start, specs = get_specs_from_subscription(subscription)
     store_specs_from_subscription(subscription.key, week_start, specs)
 
-    matches, unmatched = generate_meetings(user_list, specs[0])
+    matches, unmatched = generate_pair_meetings(user_list, specs[0])
     assert len(matches) == 2
     assert len(unmatched) == 0
 
@@ -73,7 +73,7 @@ def test_generate_meetings_with_history(minimal_database, subscription):
         (user2.key.id(), user3.key.id()),
         (user1.key.id(), user4.key.id()),
     ])
-    matches, unmatched = generate_meetings(user_list, specs[0], meeting_history)
+    matches, unmatched = generate_pair_meetings(user_list, specs[0], meeting_history)
     assert len(matches) == 0
     assert len(unmatched) == 4
 
@@ -82,7 +82,7 @@ def test_generate_meetings_with_history(minimal_database, subscription):
         (user3.key.id(), user4.key.id()),
         (user2.key.id(), user3.key.id()),
     ])
-    matches, unmatched = generate_meetings(user_list, specs[0], meeting_history)
+    matches, unmatched = generate_pair_meetings(user_list, specs[0], meeting_history)
     assert len(matches) == 1
     assert len(unmatched) == 2
 
@@ -98,7 +98,7 @@ def test_get_previous_meetings(minimal_database):
     MeetingParticipant(meeting=meeting, user=user2).put()
     MeetingParticipant(meeting=meeting, user=user1).put()
 
-    assert get_previous_meetings() == set([(user1.id(), user2.id())])
+    assert get_previous_pair_meetings() == set([(user1.id(), user2.id())])
 
 
 def test_get_previous_meetings_no_specs(database_no_specs):
@@ -112,7 +112,7 @@ def test_get_previous_meetings_no_specs(database_no_specs):
     MeetingParticipant(meeting=meeting, user=user2).put()
     MeetingParticipant(meeting=meeting, user=user1).put()
 
-    assert get_previous_meetings() == set([])
+    assert get_previous_pair_meetings() == set([])
 
 
 def test_generate_save_meetings(minimal_database, subscription):
@@ -126,8 +126,8 @@ def test_generate_save_meetings(minimal_database, subscription):
     MeetingRequest(user=user1, meeting_spec=meeting_spec.key).put()
     MeetingRequest(user=user2, meeting_spec=meeting_spec.key).put()
 
-    matches, unmatched = generate_meetings([user1.get(), user2.get()], meeting_spec)
-    save_meetings(matches, meeting_spec)
+    matches, unmatched = generate_pair_meetings([user1.get(), user2.get()], meeting_spec)
+    save_pair_meetings(matches, meeting_spec)
 
     assert unmatched == []
 
@@ -157,6 +157,6 @@ def test_no_re_matches(minimal_database):
 
     previous_meetings = {pair for pair in itertools.combinations([user.key.id() for user in users], 2)}
     previous_meetings = previous_meetings - {(users[0].key.id(), users[1].key.id())}
-    matches, unmatched = generate_meetings(users, meeting_spec, previous_meetings)
+    matches, unmatched = generate_pair_meetings(users, meeting_spec, previous_meetings)
     assert len(unmatched) == num_users - 2
     assert [(match[0].key.id(), match[1].key.id()) for match in matches] == [(users[0].key.id(), users[1].key.id())]

--- a/tests/send_email_test.py
+++ b/tests/send_email_test.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from yelp_beans.logic.meeting_spec import get_specs_for_current_week
-from yelp_beans.match import generate_meetings
+from yelp_beans.matching.pair_match import generate_pair_meetings
 from yelp_beans.models import User
 from yelp_beans.models import UserSubscriptionPreferences
 from yelp_beans.send_email import send_batch_initial_opt_in_email
@@ -63,5 +63,5 @@ def test_send_batch_meeting_confirmation_email(database):
 
 
 def test_send_batch_unmatched_email(database, fake_user):
-    matches, unmatched = generate_meetings([fake_user], database.specs[0])
+    matches, unmatched = generate_pair_meetings([fake_user], database.specs[0])
     send_batch_unmatched_email(unmatched)

--- a/yelp_beans/matching/pair_match.py
+++ b/yelp_beans/matching/pair_match.py
@@ -40,7 +40,7 @@ def is_same(field, match, users):
     return users[match[0]].metadata[field] == users[match[1]].metadata[field]
 
 
-def save_meetings(matches, spec):
+def save_pair_meetings(matches, spec):
     for match in matches:
         meeting_key = Meeting(meeting_spec=spec.key).put()
         MeetingParticipant(meeting=meeting_key, user=match[0].key).put()
@@ -52,7 +52,7 @@ def save_meetings(matches, spec):
         ))
 
 
-def get_previous_meetings(cooldown=None):
+def get_previous_pair_meetings(cooldown=None):
 
     if cooldown is None:
         cooldown = get_config()['meeting_cooldown_weeks']
@@ -104,7 +104,7 @@ def get_previous_meetings(cooldown=None):
     return disallowed_meetings
 
 
-def generate_meetings(users, spec, prev_meeting_tuples=None):
+def generate_pair_meetings(users, spec, prev_meeting_tuples=None):
     """
     Returns 2 tuples:
     - meetings: list of dicts of the same type as prev_meetings, to indicate
@@ -112,7 +112,7 @@ def generate_meetings(users, spec, prev_meeting_tuples=None):
     - unmatched_user_ids: users with no matches.
     """
     if prev_meeting_tuples is None:
-        prev_meeting_tuples = get_previous_meetings()
+        prev_meeting_tuples = get_previous_pair_meetings()
 
     uid_to_users = {user.key.id(): user for user in users}
     user_ids = sorted(uid_to_users.keys())

--- a/yelp_beans/routes/tasks.py
+++ b/yelp_beans/routes/tasks.py
@@ -13,8 +13,8 @@ from yelp_beans.logic.meeting_spec import get_specs_for_current_week
 from yelp_beans.logic.subscription import get_specs_from_subscription
 from yelp_beans.logic.subscription import store_specs_from_subscription
 from yelp_beans.logic.user import sync_employees
-from yelp_beans.match import generate_meetings
-from yelp_beans.match import save_meetings
+from yelp_beans.matching.pair_match import generate_pair_meetings
+from yelp_beans.matching.pair_match import save_pair_meetings
 from yelp_beans.models import Meeting
 from yelp_beans.models import MeetingParticipant
 from yelp_beans.models import MeetingRequest
@@ -67,8 +67,8 @@ def match_employees():
         logging.info('Users: ')
         logging.info([user.get_username() for user in users])
 
-        matches, unmatched = generate_meetings(users, spec)
-        save_meetings(matches, spec)
+        matches, unmatched = generate_pair_meetings(users, spec)
+        save_pair_meetings(matches, spec)
 
         send_batch_unmatched_email(unmatched)
         send_batch_meeting_confirmation_email(matches, spec)


### PR DESCRIPTION
- match.py is now pair_match.py
- Methods generate_meetings, get_previous_meetings, and save_meetings are now generate_pair_meetings, get_previous_pair_meetings, and save_pair_meetings
- New module 'matching' which will contain pair_match.py and (eventually) group_match.py
