### PR TITLE
Only disallow a pair if they matched earlier for the same subscription

### DIFF
--- a/tests/send_email_test.py
+++ b/tests/send_email_test.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from yelp_beans.logic.meeting_spec import get_specs_for_current_week
-from yelp_beans.matching.pair_match import generate_pair_meetings
+from yelp_beans.matching.match import generate_meetings
 from yelp_beans.models import User
 from yelp_beans.models import UserSubscriptionPreferences
 from yelp_beans.send_email import send_batch_initial_opt_in_email
@@ -63,5 +63,5 @@ def test_send_batch_meeting_confirmation_email(database):
 
 
 def test_send_batch_unmatched_email(database, fake_user):
-    matches, unmatched = generate_pair_meetings([fake_user], database.specs[0])
+    matches, unmatched = generate_meetings([fake_user], database.specs[0])
     send_batch_unmatched_email(unmatched)

--- a/yelp_beans/matching/match.py
+++ b/yelp_beans/matching/match.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from yelp_beans.matching.pair_match import generate_pair_meetings
+
+
+def generate_meetings(users, spec, prev_meeting_tuples=None, group_size=2):
+    if group_size == 2:
+        return generate_pair_meetings(users, spec, prev_meeting_tuples)
+    else:
+        raise NotImplementedError("Group matching not implemented yet.")


### PR DESCRIPTION
- Only disallow a pair if they matched earlier for the same subscription
- Added a test for the above (test_get_previous_meetings_multi_subscription)
- Further refactor to abstract out a single generate_meetings method which can accept an optional parameter for the group size.