### PR TITLE
Revert eslint-plugin-jsx-a11y version to 5.1.1 to deal with airbnb eslint incompatibilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-config-airbnb": "^15.0.1",
     "eslint-loader": "^1.6.1",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.1.0",
     "imports-loader": "^0.7.0",
     "jest": "^20.0.4",


### PR DESCRIPTION
Fixes issue #96.