### PR TITLE
Save multiple participants for a meeting into db + refactoring

### DIFF
--- a/tests/match_test.py
+++ b/tests/match_test.py
@@ -13,7 +13,7 @@ from yelp_beans.matching.group_match import get_previous_meetings_counts
 from yelp_beans.matching.match import generate_meetings
 from yelp_beans.matching.match_utils import get_counts_for_pairs
 from yelp_beans.matching.match_utils import get_previous_meetings
-from yelp_beans.matching.pair_match import save_pair_meetings
+from yelp_beans.matching.match_utils import save_meetings
 from yelp_beans.models import Meeting
 from yelp_beans.models import MeetingParticipant
 from yelp_beans.models import MeetingRequest
@@ -163,7 +163,7 @@ def test_generate_save_meetings(minimal_database, subscription):
     MeetingRequest(user=user2, meeting_spec=meeting_spec.key).put()
 
     matches, unmatched = generate_meetings([user1.get(), user2.get()], meeting_spec)
-    save_pair_meetings(matches, meeting_spec)
+    save_meetings(matches, meeting_spec)
 
     assert unmatched == []
 

--- a/yelp_beans/matching/match_utils.py
+++ b/yelp_beans/matching/match_utils.py
@@ -16,6 +16,18 @@ from yelp_beans.models import MeetingParticipant
 from yelp_beans.models import MeetingSpec
 
 
+def save_meetings(matches, spec):
+    for match in matches:
+        # Last element in match is the key for meeting time
+        matched_users = match[:-1]
+        meeting_key = Meeting(meeting_spec=spec.key).put()
+        for user in matched_users:
+            MeetingParticipant(meeting=meeting_key, user=user.key).put()
+        username_list = [user.get_username() for user in matched_users]
+        logging.info(meeting_key)
+        logging.info(', '.join(username_list))
+
+
 def get_counts_for_pairs(pairs):
     counts = {}
     for pair in pairs:

--- a/yelp_beans/matching/pair_match.py
+++ b/yelp_beans/matching/pair_match.py
@@ -10,8 +10,6 @@ import networkx as nx
 
 from yelp_beans.logic.user import user_preference
 from yelp_beans.matching.match_utils import get_previous_meetings
-from yelp_beans.models import Meeting
-from yelp_beans.models import MeetingParticipant
 
 
 def get_disallowed_meetings(users, prev_meeting_tuples, spec):
@@ -34,18 +32,6 @@ def get_disallowed_meetings(users, prev_meeting_tuples, spec):
 
 def is_same(field, match, users):
     return users[match[0]].metadata[field] == users[match[1]].metadata[field]
-
-
-def save_pair_meetings(matches, spec):
-    for match in matches:
-        meeting_key = Meeting(meeting_spec=spec.key).put()
-        MeetingParticipant(meeting=meeting_key, user=match[0].key).put()
-        MeetingParticipant(meeting=meeting_key, user=match[1].key).put()
-        logging.info(meeting_key)
-        logging.info('{}, {}'.format(
-            match[0].get_username(),
-            match[1].get_username(),
-        ))
 
 
 def generate_pair_meetings(users, spec, prev_meeting_tuples=None):

--- a/yelp_beans/routes/tasks.py
+++ b/yelp_beans/routes/tasks.py
@@ -13,8 +13,8 @@ from yelp_beans.logic.meeting_spec import get_specs_for_current_week
 from yelp_beans.logic.subscription import get_specs_from_subscription
 from yelp_beans.logic.subscription import store_specs_from_subscription
 from yelp_beans.logic.user import sync_employees
-from yelp_beans.matching.pair_match import generate_pair_meetings
-from yelp_beans.matching.pair_match import save_pair_meetings
+from yelp_beans.matching.match import generate_meetings
+from yelp_beans.matching.match_utils import save_meetings
 from yelp_beans.models import Meeting
 from yelp_beans.models import MeetingParticipant
 from yelp_beans.models import MeetingRequest
@@ -67,8 +67,8 @@ def match_employees():
         logging.info('Users: ')
         logging.info([user.get_username() for user in users])
 
-        matches, unmatched = generate_pair_meetings(users, spec)
-        save_pair_meetings(matches, spec)
+        matches, unmatched = generate_meetings(users, spec, prev_meeting_tuples=None, group_size=2)
+        save_meetings(matches, spec)
 
         send_batch_unmatched_email(unmatched)
         send_batch_meeting_confirmation_email(matches, spec)


### PR DESCRIPTION
- Renamed save_pair_meetings to save_meetings
- save_meetings now takes an additional parameter for number of participants in the meeting to be saved (this info can be parsed from the meeting. Should we do that?)

- Some refactoring