### PR TITLE
New metrics endpoints, flattened json

### DIFF
--- a/tests/logic/metrics_test.py
+++ b/tests/logic/metrics_test.py
@@ -3,19 +3,19 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from yelp_beans.logic.metrics import get_subscribed_users
+from yelp_beans.logic.metrics import get_subscribers
 from yelp_beans.models import MeetingSubscription
 
 
 def test_get_subscribed_users(database, fake_user):
-    subscribed_users = get_subscribed_users()
+    subscribed_users = get_subscribers()
     assert len(subscribed_users) == 1
     assert subscribed_users[database.sub.key.urlsafe()] == ['darwin@yelp.com']
 
 
 def test_get_subscribed_users_multiple(database, fake_user):
     subscription2 = MeetingSubscription(title='test1').put()
-    subscribed_users = get_subscribed_users()
+    subscribed_users = get_subscribers()
 
     assert len(subscribed_users) == 2
     assert subscribed_users[subscription2.urlsafe()] == []

--- a/tests/routes/api/v1/metrics_test.py
+++ b/tests/routes/api/v1/metrics_test.py
@@ -5,50 +5,82 @@ from __future__ import unicode_literals
 
 import json
 
-from yelp_beans.models import MeetingSubscription
-from yelp_beans.routes.api.v1.metrics import metrics_api
+from yelp_beans.models import Meeting
+from yelp_beans.models import MeetingParticipant
+from yelp_beans.models import MeetingRequest
+from yelp_beans.models import User
+from yelp_beans.models import UserSubscriptionPreferences
+from yelp_beans.routes.api.v1.metrics import meeting_participants
+from yelp_beans.routes.api.v1.metrics import meeting_requests
+from yelp_beans.routes.api.v1.metrics import meeting_subscribers
 
 
-def test_get_metrics(app, minimal_database):
-
-    with app.test_request_context('/v1/metrics'):
-        response = metrics_api()
-        assert response == '[]'
-
-    new_subscription = MeetingSubscription(title='test1')
-    new_subscription.put()
-
-    with app.test_request_context('/v1/metrics'):
-        response = json.loads(metrics_api())
-        assert response[0]["title"] == new_subscription.title
-        assert response[0]["key"] == new_subscription.key.urlsafe()
-        assert response[0]["week_participants"] == 0
-        assert response[0]["subscribed"] == []
+def test_get_subscribers_none(app, minimal_database):
+    with app.test_request_context('/v1/metrics/subscribers'):
+        subscribed = json.loads(meeting_subscribers())
+        assert subscribed == []
 
 
-def test_get_metrics_multiple(app, database, subscription, fake_user):
-    with app.test_request_context('/v1/metrics'):
-        response = json.loads(metrics_api())
-        assert len(response) == 1
-        response = response[0]
-        assert response['key'] == database.sub.key.urlsafe()
-        assert response['subscribed'] == ['darwin@yelp.com']
-        assert response['title'] == database.sub.title
-        assert response['week_participants'] == 1
+def test_get_subscribers(app, database, subscription, fake_user):
+    with app.test_request_context('/v1/metrics/subscribers'):
+        subscribed = json.loads(meeting_subscribers())
+        assert subscribed == [{
+            'title': 'Yelp Weekly',
+            'subscriber': 'darwin@yelp.com'
+        }]
 
-    new_subscription = MeetingSubscription(title='test1')
-    new_subscription.put()
 
-    with app.test_request_context('/v1/metrics'):
-        response = json.loads(metrics_api())
-        assert len(response) == 2
+def test_get_meeting_participants(app, database):
+    pref = UserSubscriptionPreferences(subscription=database.sub.key, preference=database.prefs[0].key)
+    pref.put()
+    user1 = User(
+        email='a@yelp.com',
+        metadata={'department': 'dept'},
+        subscription_preferences=[pref.key]
+    )
+    user1.put()
+    user2 = User(
+        email='b@yelp.com',
+        metadata={'department': 'dept'},
+        subscription_preferences=[pref.key]
+    )
+    user2.put()
+    meeting1 = Meeting(meeting_spec=database.specs[0].key, cancelled=False).put()
+    MeetingParticipant(meeting=meeting1, user=user1.key).put()
+    MeetingParticipant(meeting=meeting1, user=user2.key).put()
+    with app.test_request_context('/v1/metrics/meeting_participants'):
+        participants = json.loads(meeting_participants())
+        assert participants == [
+            {
+                'date': '2017-10-27T23:00:00',
+                'meeting': 'agx0ZXN0YmVkLXRlc3RyDQsSB01lZXRpbmcYCgw',
+                'meeting_title': 'Yelp Weekly',
+                'participant': 'a@yelp.com',
+                'time': '04:00PM'
+            },
+            {
+                'date': '2017-10-27T23:00:00',
+                'meeting': 'agx0ZXN0YmVkLXRlc3RyDQsSB01lZXRpbmcYCgw',
+                'meeting_title': 'Yelp Weekly',
+                'participant': 'b@yelp.com',
+                'time': '04:00PM'
+            }
+        ]
 
-        assert response[0]['key'] == database.sub.key.urlsafe()
-        assert response[0]['subscribed'] == [fake_user.email]
-        assert response[0]['title'] == database.sub.title
-        assert response[0]['week_participants'] == 1
 
-        assert response[1]['key'] == new_subscription.key.urlsafe()
-        assert response[1]['subscribed'] == []
-        assert response[1]['title'] == new_subscription.title
-        assert response[1]['week_participants'] == 0
+def test_get_meeting_requests(app, database):
+    pref = UserSubscriptionPreferences(subscription=database.sub.key, preference=database.prefs[0].key)
+    pref.put()
+    user = User(
+        email='a@yelp.com',
+        metadata={'department': 'dept'},
+        subscription_preferences=[pref.key]
+    )
+    user.put()
+    MeetingRequest(user=user.key, meeting_spec=database.specs[0].key).put()
+    with app.test_request_context('/v1/metrics/meeting_requests'):
+        requests = json.loads(meeting_requests())
+    assert requests == [{
+        'title': 'Yelp Weekly',
+        'user': 'a@yelp.com'
+    }]

--- a/yelp_beans/logic/metrics.py
+++ b/yelp_beans/logic/metrics.py
@@ -5,13 +5,16 @@ from __future__ import unicode_literals
 
 from collections import defaultdict
 
+from yelp_beans.logic.meeting_spec import get_meeting_datetime
 from yelp_beans.logic.meeting_spec import get_specs_for_current_week
 from yelp_beans.logic.meeting_spec import get_users_from_spec
+from yelp_beans.models import MeetingParticipant
+from yelp_beans.models import MeetingRequest
 from yelp_beans.models import MeetingSubscription
 from yelp_beans.models import User
 
 
-def get_subscribed_users():
+def get_subscribers():
     users = User.query().fetch()
     subscriptions = MeetingSubscription.query().fetch()
 
@@ -37,3 +40,52 @@ def get_current_week_participation():
         ]
 
     return participation
+
+
+def get_meeting_participants():
+    meetings = defaultdict(list)
+    participants = MeetingParticipant.query().fetch()
+    for participant in participants:
+        try:
+            email = participant.user.get().email
+            meeting = participant.meeting
+            meetings[meeting].append(email)
+        except AttributeError:
+            pass
+
+    metrics = []
+    for meeting_key in meetings.keys():
+        meeting_spec = meeting_key.get().meeting_spec.get()
+        meeting_title = meeting_spec.meeting_subscription.get().title
+        participants = meetings[meeting_key]
+        for participant in participants:
+            metrics.append(
+                {
+                    'participant': participant,
+                    'meeting': meeting_key.urlsafe(),
+                    'meeting_title': meeting_title,
+                    'date': meeting_spec.datetime.isoformat(),
+                    'time': get_meeting_datetime(meeting_spec).strftime('%I:%M%p'),
+                }
+            )
+    return metrics
+
+
+def get_meeting_requests():
+    requests = []
+    for spec in get_specs_for_current_week():
+        users = [
+            request.user.get().email
+            for request
+            in MeetingRequest.query(
+                MeetingRequest.meeting_spec == spec.key
+            ).fetch()
+        ]
+        for user in users:
+            requests.append(
+                {
+                    'title': spec.meeting_subscription.get().title,
+                    'user': user,
+                }
+            )
+    return requests


### PR DESCRIPTION
Metrics endpoints are currently not being consumed by the application.  This change allows you to quickly plug and play with Tableau or any other analysis tool instead of relying on the application for visualization.

Normally I would preserve the v1 endpoints and create a v2 rest endpoint. I decided against this based on limited adoption (based on external committers).

This change is well tested and does not affect the current operability of the matching program. 