### PR TITLE
Use first and not one for meeting spec

### DIFF
--- a/api/yelp_beans/logic/meeting_spec.py
+++ b/api/yelp_beans/logic/meeting_spec.py
@@ -41,7 +41,7 @@ def get_users_from_spec(meeting_spec):
                     preference_dt.weekday() == meeting_spec.datetime.weekday():
 
                 user = User.query.filter(
-                    User.id == user_preference.user_id).one()
+                    User.id == user_preference.user_id).first()
                 logging.info('user added: ')
                 logging.info(user)
                 users.append(user)

--- a/api/yelp_beans/logic/meeting_spec.py
+++ b/api/yelp_beans/logic/meeting_spec.py
@@ -42,9 +42,10 @@ def get_users_from_spec(meeting_spec):
 
                 user = User.query.filter(
                     User.id == user_preference.user_id).first()
-                logging.info('user added: ')
-                logging.info(user)
-                users.append(user)
+                if user is not None:
+                    logging.info('user added: ')
+                    logging.info(user)
+                    users.append(user)
 
     return users
 


### PR DESCRIPTION
Run into this bug when a meeting time used to have subscribers then loses all subscribers. With one this raises an exception but the previous behavior using ndb was the equivalent of first