### PR TITLE
Remote friendly copy updates

### DIFF
--- a/api/yelp_beans/templates/match_email.html
+++ b/api/yelp_beans/templates/match_email.html
@@ -5,7 +5,7 @@
         <p>Hey {{user.first_name}}! </p>
         <p>
             Congrats! We've matched you this week for Yelp Beans ({{meeting_title}})! Feel free to talk to your match about when
-            you'd like to meet, but we suggest meeting on {{meeting_start_day}} from {{meeting_start_time}} to 
+            you'd like to meet, but we suggest meeting on {{meeting_start_day}} from {{meeting_start_time}} to
             {{meeting_end_time}}. Here's who you are meeting:
         </p>
     </td>

--- a/api/yelp_beans/templates/match_email.html
+++ b/api/yelp_beans/templates/match_email.html
@@ -4,8 +4,8 @@
     <td>
         <p>Hey {{user.first_name}}! </p>
         <p>
-            Congrats! We've matched you this week for Yelp Beans ({{meeting_title}}) on {{meeting_start_day}}
-            from {{meeting_start_time}} to {{meeting_end_time}}.Here's who you are meeting:
+            Congrats! We've matched you this week for Yelp Beans ({{meeting_title}})! Feel free to talk to your match about when you'd like to meet, but we suggest meeting on {{meeting_start_day}}
+            from {{meeting_start_time}} to {{meeting_end_time}}. Here's who you are meeting:
         </p>
     </td>
 </tr>
@@ -34,11 +34,7 @@
     <td>
         <p><b>When:</b> {{meeting_start_date}} from {{meeting_start_time}} to {{meeting_end_time}} (<a
                 href={{calendar_invite_url}}>Add to calendar</a>)</p>
-        <p><b>Where:</b> {{ location }}</p>
 
-        <p><b>Reschedule Policy:</b> Things happen. We get it. If you need to reschedule, please contact
-            the matched yelper and suggest a new time/place for the meeting.
-        </p>
         <p><b>Meeting Advice:</b> We suggest keeping the meeting short (30 mins). Introduce yourselves,
             talk about your background, what you're working on at Yelp.
         </p>

--- a/api/yelp_beans/templates/match_email.html
+++ b/api/yelp_beans/templates/match_email.html
@@ -4,8 +4,9 @@
     <td>
         <p>Hey {{user.first_name}}! </p>
         <p>
-            Congrats! We've matched you this week for Yelp Beans ({{meeting_title}})! Feel free to talk to your match about when you'd like to meet, but we suggest meeting on {{meeting_start_day}}
-            from {{meeting_start_time}} to {{meeting_end_time}}. Here's who you are meeting:
+            Congrats! We've matched you this week for Yelp Beans ({{meeting_title}})! Feel free to talk to your match about when
+            you'd like to meet, but we suggest meeting on {{meeting_start_day}} from {{meeting_start_time}} to 
+            {{meeting_end_time}}. Here's who you are meeting:
         </p>
     </td>
 </tr>

--- a/api/yelp_beans/templates/unmatched_email.html
+++ b/api/yelp_beans/templates/unmatched_email.html
@@ -4,9 +4,11 @@
     <td>
         <p>Hi there {{first_name}}!</p>
         <p>
-            Sorry we couldn't find a match for you this week for {{meeting_title}}. :( This usually happens because there were an odd
-            number of people that signed up for the week, or people signed up for a time slot you haven't signed up for. To maximize your chances of getting a match, <a href="https://{{project}}.appspot.com" style="color: #666666; text-decoration: underline;">sign up for more time slots!</a> If you have any questions please reach out to
-            rkwills@yelp.com
+            Sorry we couldn't find a match for you this week for {{meeting_title}}. :( This usually happens because there were an
+            odd number of people that signed up for the week, or people signed up for a time slot you haven't signed up for. To 
+            maximize your chances of getting a match, 
+            <a href="https://{{project}}.appspot.com" style="color: #666666; text-decoration: underline;"> sign up for more time
+            slots!</a> If you have any questions please reach out to rkwills@yelp.com
         </p>
     </td>
 </tr>

--- a/api/yelp_beans/templates/unmatched_email.html
+++ b/api/yelp_beans/templates/unmatched_email.html
@@ -4,8 +4,8 @@
     <td>
         <p>Hi there {{first_name}}!</p>
         <p>
-            Sorry we couldn't find a match for you this week. :( This usually happens because there were an odd
-            number of people that signed up for the week. If you have any questions please reach out to
+            Sorry we couldn't find a match for you this week for {{meeting_title}}. :( This usually happens because there were an odd
+            number of people that signed up for the week, or people signed up for a time slot you haven't signed up for. To maximize your chances of getting a match, <a href="https://{{project}}.appspot.com" style="color: #666666; text-decoration: underline;">sign up for more time slots!</a> If you have any questions please reach out to
             rkwills@yelp.com
         </p>
     </td>

--- a/api/yelp_beans/templates/unmatched_email.html
+++ b/api/yelp_beans/templates/unmatched_email.html
@@ -5,8 +5,8 @@
         <p>Hi there {{first_name}}!</p>
         <p>
             Sorry we couldn't find a match for you this week for {{meeting_title}}. :( This usually happens because there were an
-            odd number of people that signed up for the week, or people signed up for a time slot you haven't signed up for. To 
-            maximize your chances of getting a match, 
+            odd number of people that signed up for the week, or people signed up for a time slot you haven't signed up for. To
+            maximize your chances of getting a match,
             <a href="https://{{project}}.appspot.com" style="color: #666666; text-decoration: underline;"> sign up for more time
             slots!</a> If you have any questions please reach out to rkwills@yelp.com
         </p>

--- a/api/yelp_beans/templates/weekly_opt_in_email.html
+++ b/api/yelp_beans/templates/weekly_opt_in_email.html
@@ -4,7 +4,7 @@
     <td>
         <p>Hey {{first_name}},</p>
         <p>
-            Would you like to meet someone new this week in {{meeting_title}}? This meeting is officially on {{meeting_day}}
+            Would you like to meet someone new this week This meeting is officially on {{meeting_day}}
             at {{meeting_time}}, but the time and date can be flexible.
         </p>
     </td>

--- a/api/yelp_beans/templates/weekly_opt_in_email.html
+++ b/api/yelp_beans/templates/weekly_opt_in_email.html
@@ -4,8 +4,8 @@
     <td>
         <p>Hey {{first_name}},</p>
         <p>
-            Would you like to meet someone new this week? Your meetings are on {{meeting_day}}
-            at {{meeting_time}} in the {{office}} at the {{location}}.
+            Would you like to meet someone new this week in {{meeting_title}}? This meeting is officially on {{meeting_day}}
+            at {{meeting_time}}, but the time and date can be flexible.
         </p>
     </td>
 </tr>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4543,7 +4543,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -7393,7 +7394,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }
@@ -8322,7 +8324,8 @@
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
@@ -15829,7 +15832,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }


### PR DESCRIPTION
## Why?
We want to make this tool more remote friendly 😄 

## What?
I've changed some copy to leave out locations and allow users to set whatever time they want. I think some users may set aside time every week to do beans meetings, in which case we may want to let them specify that they are only interested in having a meeting at that time specifically. We might also consider letting users set up a https://whenisgood.net/ style thing where they can choose to only match people with overlapping availability. We could also get that availability from users' calendars if we wanted to.

I've also considered that rather than removing location info from copy, we could send down "remote" as the office and "video call" as the location. That may actually be a better solution.

We could also have different templates for remote and in person companies, and let Beans users choose. 