### PR TITLE
Changes made to deploy to appengine from scratch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ PROJECT := $(call GetFromPkg,PROJECT)
 
 
 .PHONY: deploy
-deploy: build deploy_dispatch
-	gcloud app deploy frontend/app.yaml api/app.yaml --project $(PROJECT) --version 1
+deploy: deploy_services deploy_dispatch
 
 .PHONY: development
 development:
@@ -24,13 +23,18 @@ test:
 	make -C frontend/ test
 	make -C api/ test
 
+
+.PHONY: deploy_services
+deploy_services: build
+	gcloud app deploy frontend/app.yaml api/app.yaml --project $(PROJECT) --version 1
+
 .PHONY: deploy_dispatch
 deploy_dispatch:
 	gcloud app deploy dispatch.yaml --project $(PROJECT)
 
 .PHONY: deploy_cron
 deploy_cron:
-	gcloud app deploy cron.yaml --project $(PROJECT)
+	gcloud app deploy api/cron.yaml --project $(PROJECT)
 
 .PHONY: clean
 clean:

--- a/api/.gcloudignore
+++ b/api/.gcloudignore
@@ -17,3 +17,4 @@
 __pycache__/
 # Ignored by the build system
 /setup.cfg
+/.tox


### PR DESCRIPTION
- Don't include .tox in the upload to appengine, since it is unused and
  causes to exceed the maximum number of files
- Adjust the Makefile to deploy the services before deploying the
  dispatch. You can't deploy the dispatch if the service referenced in
  the dispatch file doesn't exist yet.
- Update the path of the cron file

Dry running the deploy shows that it will deploy the frontend and api before the dispatch file
```
% make deploy --dry-run 
make -C frontend/
make -C api/
gcloud app deploy frontend/app.yaml api/app.yaml --project project-name --version 1
gcloud app deploy dispatch.yaml --project project-name
```