### PR TITLE
Make route parameter name match function argument

### DIFF
--- a/api/yelp_beans/routes/api/v1/preferences.py
+++ b/api/yelp_beans/routes/api/v1/preferences.py
@@ -28,7 +28,7 @@ def preferences_api():
     return resp
 
 
-@preferences_blueprint.route('/subscription/<subscription>', methods=["POST"])
+@preferences_blueprint.route('/subscription/<subscription_id>', methods=["POST"])
 def preferences_api_post(subscription_id):
     data = request.json
     user = get_user(data.get('email'))


### PR DESCRIPTION
When I was running beans locally this was causing a 5xx when hitting the
endpoint. There is already an existing test for this endpoint, so I am
surprised that the test passed when it 5xx when running it locally.