### PR TITLE
Improve performance of v1/metrics/ endpoints

### DIFF
--- a/api/tests/logic/metrics_test.py
+++ b/api/tests/logic/metrics_test.py
@@ -1,5 +1,6 @@
 from yelp_beans.logic.metrics import get_subscribers
 from yelp_beans.models import MeetingSubscription
+from yelp_beans.models import UserSubscriptionPreferences
 
 
 def test_get_subscribed_users(database, fake_user):
@@ -16,4 +17,14 @@ def test_get_subscribed_users_multiple(database, fake_user, session):
 
     assert len(subscribed_users) == 2
     assert subscribed_users[subscription2.id] == []
+    assert subscribed_users[database.sub.id] == ['darwin@yelp.com']
+
+
+def test_get_subscribers_null_sub_id(database, fake_user, session):
+    sub_pref = UserSubscriptionPreferences(user_id=fake_user.id, subscription_id=None)
+    session.add(sub_pref)
+    session.commit()
+    subscribed_users = get_subscribers()
+
+    assert len(subscribed_users) == 1
     assert subscribed_users[database.sub.id] == ['darwin@yelp.com']

--- a/api/yelp_beans/logic/meeting_spec.py
+++ b/api/yelp_beans/logic/meeting_spec.py
@@ -9,10 +9,14 @@ from yelp_beans.models import User
 from yelp_beans.models import UserSubscriptionPreferences
 
 
-def get_specs_for_current_week():
+def get_specs_for_current_week_query():
     week_start = datetime.now() - timedelta(days=datetime.now().weekday())
     week_start.replace(hour=0, minute=0, second=0, microsecond=0)
-    return MeetingSpec.query.filter(MeetingSpec.datetime > week_start).all()
+    return MeetingSpec.query.filter(MeetingSpec.datetime > week_start)
+
+
+def get_specs_for_current_week():
+    return get_specs_for_current_week_query().all()
 
 
 def get_users_from_spec(meeting_spec):

--- a/api/yelp_beans/logic/meeting_spec.py
+++ b/api/yelp_beans/logic/meeting_spec.py
@@ -60,6 +60,8 @@ def get_meeting_datetime(meeting_spec: MeetingSpec, subscription_timezone: Optio
     """
     Given a meeting_spec, returns the meeting datetime in the appropriate timezone.
     :param meeting_spec: models.meeting_spec
+    :param subscription_timezone: Optional[str] - Timezone of the subscription. Falls back to getting
+        timezone from the meeting_spec subscription reference
     :return: datetime.datetime in the correct timezone
     """
     meeting_datetime = meeting_spec.datetime

--- a/api/yelp_beans/logic/meeting_spec.py
+++ b/api/yelp_beans/logic/meeting_spec.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 from datetime import timedelta
+from typing import Optional
 
 from pytz import timezone
 from pytz import utc
@@ -55,7 +56,7 @@ def get_users_from_spec(meeting_spec):
     return users
 
 
-def get_meeting_datetime(meeting_spec):
+def get_meeting_datetime(meeting_spec: MeetingSpec, subscription_timezone: Optional[str] = None) -> datetime:
     """
     Given a meeting_spec, returns the meeting datetime in the appropriate timezone.
     :param meeting_spec: models.meeting_spec
@@ -63,5 +64,8 @@ def get_meeting_datetime(meeting_spec):
     """
     meeting_datetime = meeting_spec.datetime
 
-    meeting_timezone = meeting_spec.meeting_subscription.timezone
+    if subscription_timezone is None:
+        meeting_timezone = meeting_spec.meeting_subscription.timezone
+    else:
+        meeting_timezone = subscription_timezone
     return meeting_datetime.replace(tzinfo=utc).astimezone(timezone(meeting_timezone))

--- a/api/yelp_beans/logic/metrics.py
+++ b/api/yelp_beans/logic/metrics.py
@@ -10,22 +10,19 @@ from yelp_beans.models import MeetingParticipant
 from yelp_beans.models import MeetingRequest
 from yelp_beans.models import MeetingSpec
 from yelp_beans.models import MeetingSubscription
-from yelp_beans.models import User
+from yelp_beans.models import UserSubscriptionPreferences
 
 
 def get_subscribers():
-    users = User.query.all()
+    sub_prefs = UserSubscriptionPreferences.query.options(joinedload(UserSubscriptionPreferences.user)).all()
     subscriptions = MeetingSubscription.query.all()
 
-    metrics = defaultdict(set)
     # creates metrics keys for all subscriptions including ones without users
-    for subscription in subscriptions:
-        metrics[subscription.id] = []
+    metrics = {subscription.id: [] for subscription in subscriptions}
 
     # creates metrics keys for all subscriptions that have users with user data
-    for user in users:
-        for preference in user.subscription_preferences:
-            metrics[preference.subscription_id].append(user.email)
+    for preference in sub_prefs:
+        metrics[preference.subscription_id].append(preference.user.email)
 
     return metrics
 

--- a/api/yelp_beans/logic/metrics.py
+++ b/api/yelp_beans/logic/metrics.py
@@ -14,7 +14,11 @@ from yelp_beans.models import UserSubscriptionPreferences
 
 
 def get_subscribers():
-    sub_prefs = UserSubscriptionPreferences.query.options(joinedload(UserSubscriptionPreferences.user)).all()
+    sub_prefs = UserSubscriptionPreferences.query.options(
+        joinedload(UserSubscriptionPreferences.user),
+    ).filter(
+        UserSubscriptionPreferences.subscription_id.isnot(None),
+    ).all()
     subscriptions = MeetingSubscription.query.all()
 
     # creates metrics keys for all subscriptions including ones without users

--- a/api/yelp_beans/models.py
+++ b/api/yelp_beans/models.py
@@ -71,6 +71,7 @@ class UserSubscriptionPreferences(db.Model):
     """
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    user = db.relationship('User')
     subscription_id = db.Column(db.Integer, db.ForeignKey('meeting_subscription.id'))
     subscription = db.relationship('MeetingSubscription',
                                    backref=db.backref("user_subscription_preferences", uselist=False))


### PR DESCRIPTION
There were n+1 queries that caused us to need a lot of queries to load each endpoint. I mainly added a bunch of joins to get it all in one query, but I did rework the logic a little bit.

The test failures are the same tests that are failing on master.

### Improve performance of v1/metrics/meetings endpoint

This reduces the number of sql queries from 1 query to get the meeting
participants, one per participant, and 3 per meeting that had a
participant to 1 query to get the meeting participants. This does make
the query faster, but I am not sure if doing this many joins will result
in this query becoming slow as the number of meetings grows.
Eventually we should add required query params to reduce the amount of
data that needs to be returned.

### Improve performance of v1/metrics/subscribers endpoint

This reduces the number of sql queries from 1 query to get the users and
then 1 query per user to 1 query. We could have kept the same behavior
of querying the User table and joining on UserSubscriptionPreferences to
reduce it to one query, but I think we expect a lot of users to not have
any subscriptions at all. Therefore going the other direction should result in
better performance.

### Improve performance of v1/metrics/requests endpoint

This reduces the number of sql queries down to 2 queries. Previously it
would do 1 to get meeting specs, 1 per meeting spec to get related
meeting requests and then 2 per meeting request (1 to get user email and
another to get the subscription title).