### PR TITLE
Add task endpoint to clean user subscription preferences

### DIFF
--- a/api/cron.yaml
+++ b/api/cron.yaml
@@ -5,6 +5,12 @@ cron:
   timezone: America/Los_Angeles
   target: api
 
+- description: clean user subscriptions
+  url: /tasks/clean_user_subscriptions
+  schedule: every day 4:00
+  timezone: America/Los_Angeles
+  target: api
+
 - description: weekly meeting spec generation
   url: /tasks/generate_meeting_specs_for_week
   schedule: every monday 6:00

--- a/api/tests/logic/user_test.py
+++ b/api/tests/logic/user_test.py
@@ -271,40 +271,44 @@ def test_add_preferences_adds_multiple_on_opt_in(session, subscription):
     assert user.subscription_preferences[1].preference in (preference_1, preference_2)
 
 
-def is_valid_user_subscription_preference_no_subscription(subscription):
+def test_is_valid_user_subscription_preference_no_subscription(subscription):
     preference = subscription.datetime[0]
     user = User(email='a@yelp.com', meta_data={'department': 'dept'})
     user_sub = UserSubscriptionPreferences(preference=preference, subscription_id=None, user=user)
     subscription.user_rules = [Rule(name='department', value='dept')]
+    subscription.rule_logic = 'all'
 
     result = is_valid_user_subscription_preference(user_sub, None)
     assert not result
 
 
-def is_valid_user_subscription_preference_user_terminated(subscription):
+def test_is_valid_user_subscription_preference_user_terminated(subscription):
     preference = subscription.datetime[0]
-    user = User(email='a@yelp.com', meta_data={'department': 'dept'})
+    user = User(email='a@yelp.com', meta_data={'department': 'dept'}, terminated=True)
     user_sub = UserSubscriptionPreferences(preference=preference, subscription_id=subscription.id, user=user)
     subscription.user_rules = [Rule(name='department', value='dept')]
+    subscription.rule_logic = 'all'
 
     result = is_valid_user_subscription_preference(user_sub, subscription)
     assert not result
 
-def is_valid_user_subscription_preference_fails_rules(subscription):
+def test_is_valid_user_subscription_preference_fails_rules(subscription):
     preference = subscription.datetime[0]
     user = User(email='a@yelp.com', meta_data={'department': 'dept'})
     user_sub = UserSubscriptionPreferences(preference=preference, subscription_id=subscription.id, user=user)
     subscription.user_rules = [Rule(name='department', value='other dept')]
+    subscription.rule_logic = 'all'
 
     result = is_valid_user_subscription_preference(user_sub, subscription)
     assert not result
 
 
-def is_valid_user_subscription_preference_valid(subscription):
+def test_is_valid_user_subscription_preference_valid(subscription):
     preference = subscription.datetime[0]
     user = User(email='a@yelp.com', meta_data={'department': 'dept'})
     user_sub = UserSubscriptionPreferences(preference=preference, subscription_id=subscription.id, user=user)
     subscription.user_rules = [Rule(name='department', value='dept')]
+    subscription.rule_logic = 'all'
 
     result = is_valid_user_subscription_preference(user_sub, subscription)
     assert result

--- a/api/tests/logic/user_test.py
+++ b/api/tests/logic/user_test.py
@@ -2,6 +2,7 @@ import pytest
 from yelp_beans.logic.user import add_preferences
 from yelp_beans.logic.user import create_new_employees_from_list
 from yelp_beans.logic.user import hash_employee_data
+from yelp_beans.logic.user import is_valid_user_subscription_preference
 from yelp_beans.logic.user import mark_termed_employees
 from yelp_beans.logic.user import remove_preferences
 from yelp_beans.logic.user import sync_employees
@@ -9,6 +10,7 @@ from yelp_beans.logic.user import update_current_employees
 from yelp_beans.logic.user import user_preference
 from yelp_beans.logic.user import validate_employee_data
 from yelp_beans.models import MeetingSpec
+from yelp_beans.models import Rule
 from yelp_beans.models import User
 from yelp_beans.models import UserSubscriptionPreferences
 
@@ -267,3 +269,42 @@ def test_add_preferences_adds_multiple_on_opt_in(session, subscription):
     user = User.query.filter(User.id == user.id).one()
     assert user.subscription_preferences[0].preference in (preference_1, preference_2)
     assert user.subscription_preferences[1].preference in (preference_1, preference_2)
+
+
+def is_valid_user_subscription_preference_no_subscription(subscription):
+    preference = subscription.datetime[0]
+    user = User(email='a@yelp.com', meta_data={'department': 'dept'})
+    user_sub = UserSubscriptionPreferences(preference=preference, subscription_id=None, user=user)
+    subscription.user_rules = [Rule(name='department', value='dept')]
+
+    result = is_valid_user_subscription_preference(user_sub, None)
+    assert not result
+
+
+def is_valid_user_subscription_preference_user_terminated(subscription):
+    preference = subscription.datetime[0]
+    user = User(email='a@yelp.com', meta_data={'department': 'dept'})
+    user_sub = UserSubscriptionPreferences(preference=preference, subscription_id=subscription.id, user=user)
+    subscription.user_rules = [Rule(name='department', value='dept')]
+
+    result = is_valid_user_subscription_preference(user_sub, subscription)
+    assert not result
+
+def is_valid_user_subscription_preference_fails_rules(subscription):
+    preference = subscription.datetime[0]
+    user = User(email='a@yelp.com', meta_data={'department': 'dept'})
+    user_sub = UserSubscriptionPreferences(preference=preference, subscription_id=subscription.id, user=user)
+    subscription.user_rules = [Rule(name='department', value='other dept')]
+
+    result = is_valid_user_subscription_preference(user_sub, subscription)
+    assert not result
+
+
+def is_valid_user_subscription_preference_valid(subscription):
+    preference = subscription.datetime[0]
+    user = User(email='a@yelp.com', meta_data={'department': 'dept'})
+    user_sub = UserSubscriptionPreferences(preference=preference, subscription_id=subscription.id, user=user)
+    subscription.user_rules = [Rule(name='department', value='dept')]
+
+    result = is_valid_user_subscription_preference(user_sub, subscription)
+    assert result

--- a/api/tests/routes/tasks_test.py
+++ b/api/tests/routes/tasks_test.py
@@ -1,6 +1,12 @@
+from datetime import datetime
+
 from yelp_beans.models import MeetingSpec
+from yelp_beans.models import MeetingSubscription
+from yelp_beans.models import Rule
+from yelp_beans.models import SubscriptionDateTime
 from yelp_beans.models import User
 from yelp_beans.models import UserSubscriptionPreferences
+from yelp_beans.routes.tasks import clean_user_subscriptions
 from yelp_beans.routes.tasks import generate_meeting_specs
 from yelp_beans.routes.tasks import weekly_opt_in
 
@@ -40,3 +46,39 @@ def test_weekly_opt_in(session, subscription):
 
     response = weekly_opt_in()
     assert response == 'OK'
+
+
+def test_clean_user_subscriptions(session):
+    preference = SubscriptionDateTime(datetime=datetime(2017, 1, 20, 23, 0))
+    subscription = MeetingSubscription(
+        title='Test Weekly',
+        size=2,
+        location='8th Floor',
+        office='USA: CA SF New Montgomery Office',
+        timezone='America/Los_Angeles',
+        datetime=[preference],
+        user_rules=[Rule(name='department', value='dept')],
+        rule_logic='all',
+    )
+    user_1 = User(
+        email="a@yelp.com",
+        meta_data={'department': 'dept'},
+        subscription_preferences=[UserSubscriptionPreferences(preference=preference, subscription=subscription)],
+    )
+    # Should be removed because of incorrect department
+    user_2 = User(
+        email="a@yelp.com",
+        meta_data={'department': 'other dept'},
+        subscription_preferences=[UserSubscriptionPreferences(preference=preference, subscription=subscription)],
+    )
+
+    session.add(subscription)
+    session.add(user_1)
+    session.add(user_2)
+    session.commit()
+
+    response = clean_user_subscriptions()
+    assert response == 'OK'
+
+    user_sub_prefs = UserSubscriptionPreferences.query.all()
+    assert len(user_sub_prefs) == 1

--- a/api/yelp_beans/routes/tasks.py
+++ b/api/yelp_beans/routes/tasks.py
@@ -1,11 +1,14 @@
 import logging
 
 from flask import Blueprint
+from sqlalchemy.orm import joinedload
 from yelp_beans.logic.data_ingestion import DataIngestion
 from yelp_beans.logic.meeting_spec import get_meeting_datetime
 from yelp_beans.logic.meeting_spec import get_specs_for_current_week
 from yelp_beans.logic.subscription import get_specs_from_subscription
 from yelp_beans.logic.subscription import store_specs_from_subscription
+from yelp_beans.logic.user import delete_user_subscription_preference
+from yelp_beans.logic.user import is_valid_user_subscription_preference
 from yelp_beans.logic.user import sync_employees
 from yelp_beans.matching.match import generate_meetings
 from yelp_beans.matching.match_utils import save_meetings
@@ -13,6 +16,7 @@ from yelp_beans.models import Meeting
 from yelp_beans.models import MeetingParticipant
 from yelp_beans.models import MeetingRequest
 from yelp_beans.models import MeetingSubscription
+from yelp_beans.models import UserSubscriptionPreferences
 from yelp_beans.send_email import send_batch_meeting_confirmation_email
 from yelp_beans.send_email import send_batch_unmatched_email
 from yelp_beans.send_email import send_batch_weekly_opt_in_email
@@ -88,3 +92,24 @@ def send_match_emails():
         logging.info(matches)
         send_batch_meeting_confirmation_email(matches, spec)
     return "OK"
+
+
+@tasks.route('/clean_user_subscriptions', methods=['GET'])
+def clean_user_subscriptions():
+    subscriptions = MeetingSubscription.query.options(
+        joinedload(MeetingSubscription.user_rules),
+    ).all()
+    subscription_id_to_subscription = {subscription.id: subscription for subscription in subscriptions}
+
+    sub_prefs = UserSubscriptionPreferences.query.options(
+        joinedload(UserSubscriptionPreferences.user),
+    ).all()
+
+    for preference in sub_prefs:
+        subscription = subscription_id_to_subscription.get(preference.subscription_id)
+        is_valid = is_valid_user_subscription_preference(preference, subscription)
+        if not is_valid:
+            delete_user_subscription_preference(preference)
+            logging.info(f'Deleted UserSubscriptionPreference<{preference.id}>')
+
+    return 'OK'


### PR DESCRIPTION
This removes user subscription preferences if the user is terminated, no
longer is eligible for the meeting subscription, or the subscription has
been deleted.

I scheduled this to be ran daily an hour after the employee sync. One
hour should be more than enough time for the employee sync to finish.

Having `apply_rules` accept a dict and a model is weird. Existing code
is calling it with a dict, but we tend be passing around the model in
logic files. We should probably convert it to using a model in all
places, but I am not sure why it previously used a dict (seems like
extra effort, so maybe there is a good reason).

Only need look at the last commit. This uses the relationship that I added to the
UserSubscriptionPreference model in #146, so I had to build on top of it.