### PR TITLE
Fix how we calculate meeting time for the current current week

### DIFF
--- a/api/yelp_beans/logic/meeting_spec.py
+++ b/api/yelp_beans/logic/meeting_spec.py
@@ -27,6 +27,7 @@ def get_users_from_spec(meeting_spec):
 
     logging.info('User Preferences')
     logging.info(user_sub_preferences)
+    meeting_timezone = timezone(meeting_spec.meeting_subscription.timezone)
     users = []
     for user_preference in user_sub_preferences:
 
@@ -34,11 +35,12 @@ def get_users_from_spec(meeting_spec):
             logging.info('User Preference')
             logging.info(user_preference.preference)
             logging.info(user_preference.preference.__dict__)
-            preference_dt = user_preference.preference.datetime
+            preference_dt = user_preference.preference.datetime.replace(tzinfo=utc).astimezone(meeting_timezone)
+            meeting_spec_dt = meeting_spec.datetime.replace(tzinfo=utc).astimezone(meeting_timezone)
 
-            if preference_dt.hour == meeting_spec.datetime.hour and \
-                    preference_dt.minute == meeting_spec.datetime.minute and \
-                    preference_dt.weekday() == meeting_spec.datetime.weekday():
+            if preference_dt.hour == meeting_spec_dt.hour and \
+                    preference_dt.minute == meeting_spec_dt.minute and \
+                    preference_dt.weekday() == meeting_spec_dt.weekday():
 
                 user = User.query.filter(
                     User.id == user_preference.user_id).one()


### PR DESCRIPTION
When calculating the datetime of the meeting for the current week, we
did not account for the meeting timezone. This then lead to the wrong
time being generated when the SubscriptionDatetime is stored in utc, but
the MeetingSubscription timezone is a timezone that has daylight
savings. Easiest to explain this with an example:

SubscriptionDatetime:
    Stored: 01/06/2021 11:00 UTC
    Expected America/Los_Angeles time: 03:00 since offset is -8

Calculate meeting on week of 05/17/2021:
    Calculated Time ignoring timezone: 05/19/2021 11:00 UTC
    America/Los_Angeles time: 04:00 since offset is now -7

    Calculating Time with timezone:
        Base time: 01/06/2021 11:00 UTC -> 01/06/2021 03:00 -8
        Date after replacing time: 05/19/2021 03:00 -7
        Calculated time: 05/19/2021 10:00 UTC

Let me know if this makes sense, tried my best at an explanation. The logic
for going from UTC naive datetime to meeting subscription timezone datetime
could potentially be moved to a function, but for now I decided to repeat it a little.