### PR TITLE
Add retries for the weekly meeting spec generation batch

### DIFF
--- a/api/cron.yaml
+++ b/api/cron.yaml
@@ -16,6 +16,8 @@ cron:
   schedule: every monday 6:00
   timezone: America/Los_Angeles
   target: api
+  retry_parameters:
+    min_backoff_seconds: 30
 
 - description: weekly opt-in email
   url: /tasks/email_users_for_weekly_opt_in


### PR DESCRIPTION
Made the min_backoff_seconds fairly big to help ensure what caused the
issue was resolved and we have 3 hours to successfully run this job.
Also the default of 5 retries seemed fine, so it didn't seem worth
messing with.

See the [google docs about cron](https://cloud.google.com/appengine/docs/flexible/nodejs/scheduling-jobs-with-cron-yaml#retries) for more details about this.