### PR TITLE
Auto generate meeting requests for users who automatically renew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 beans.code-workspace
 config.json
 node_modules/
+.DS_Store
+.vscode/

--- a/api/alembic.ini
+++ b/api/alembic.ini
@@ -1,0 +1,89 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = migrations
+
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date
+# within the migration file as well as the filename.
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; this defaults
+# to migrations/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path
+# version_locations = %(here)s/bar %(here)s/bat migrations/versions
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/api/cron.yaml
+++ b/api/cron.yaml
@@ -19,7 +19,8 @@ cron:
   retry_parameters:
     min_backoff_seconds: 30
 
-- description: weekly meeting spec generation
+# This needs to be run after the specs are generated, and before opt-in emails are sent out
+- description: generate meeting requests for users to auto renew
   url: /tasks/generate_meeting_requests_for_users_who_auto_renew
   schedule: every monday 6:30
   timezone: America/Los_Angeles

--- a/api/cron.yaml
+++ b/api/cron.yaml
@@ -19,6 +19,14 @@ cron:
   retry_parameters:
     min_backoff_seconds: 30
 
+- description: weekly meeting spec generation
+  url: /tasks/generate_meeting_requests_for_users_who_auto_renew
+  schedule: every monday 6:30
+  timezone: America/Los_Angeles
+  target: api
+  retry_parameters:
+    min_backoff_seconds: 30
+
 - description: weekly opt-in email
   url: /tasks/email_users_for_weekly_opt_in
   schedule: every monday 9:00

--- a/api/migrations/README
+++ b/api/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/api/migrations/env.py
+++ b/api/migrations/env.py
@@ -1,0 +1,76 @@
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/api/migrations/script.py.mako
+++ b/api/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/api/migrations/versions/05cd9f31ac0d_add_auto_renewal_column_to_.py
+++ b/api/migrations/versions/05cd9f31ac0d_add_auto_renewal_column_to_.py
@@ -1,0 +1,26 @@
+"""add auto_renewal column to UserSubscriptionPreferences
+
+Revision ID: 05cd9f31ac0d
+Revises:
+Create Date: 2021-08-19 22:16:40.072931
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '05cd9f31ac0d'  # pragma: allowlist secret
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'UserSubscriptionPreferences',
+        sa.Column('auto_renew', sa.Boolean(), nullable=False, server_default=False)
+    )
+
+
+def downgrade():
+    op.drop_column('UserSubscriptionPreferences', 'auto_renew')

--- a/api/requirements-minimal.txt
+++ b/api/requirements-minimal.txt
@@ -1,3 +1,4 @@
+alembic
 boto3
 Flask
 flask-api-utils

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,3 +1,4 @@
+alembic==1.6.5
 boto3==1.16.45
 botocore==1.19.45
 certifi==2020.12.5

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -13,10 +13,12 @@ idna==2.10
 itsdangerous==1.1.0
 Jinja2==2.11.3
 jmespath==0.10.0
+mako==1.1.5
 MarkupSafe==1.1.1
 networkx==2.5
 psycopg2-binary==2.8.6
 python-dateutil==2.8.1
+python-editor==1.0.4
 python-http-client==3.3.1
 pytz==2020.5
 PyYAML==5.4

--- a/api/tests/logic/subscription_test.py
+++ b/api/tests/logic/subscription_test.py
@@ -70,11 +70,13 @@ def test_merge_subscriptions_with_preferences(database, fake_user):
                 'active': False,
                 'date': '2017-01-20T19:00:00+00:00',
                 'id': database.sub.datetime[1].id
+
             },
             {
                 'active': True,
                 'date': '2017-01-20T23:00:00+00:00',
-                'id': database.sub.datetime[0].id
+                'id': database.sub.datetime[0].id,
+                'auto_renew': False
             }
         ]
     }

--- a/api/tests/logic/user_test.py
+++ b/api/tests/logic/user_test.py
@@ -245,7 +245,7 @@ def test_add_preferences_adds_on_opt_in(session, subscription):
     session.add(user)
     session.commit()
 
-    updated_preferences = {preference.id: True}
+    updated_preferences = {preference.id: {'enabled': True, 'autoRenew': False}}
     assert len(user.subscription_preferences) == 0
     added = add_preferences(user, updated_preferences, subscription.id)
     assert added.pop() == preference.id

--- a/api/tests/logic/user_test.py
+++ b/api/tests/logic/user_test.py
@@ -260,7 +260,10 @@ def test_add_preferences_adds_multiple_on_opt_in(session, subscription):
     session.add(user)
     session.commit()
 
-    updated_preferences = {preference_1.id: True, preference_2.id: True}
+    updated_preferences = {
+        preference_1.id: {'enabled': True, 'autoRenew': False},
+        preference_2.id: {'enabled': True, 'autoRenew': False}
+    }
     assert len(user.subscription_preferences) == 0
     added = add_preferences(user, updated_preferences, subscription.id)
     assert preference_1.id in added

--- a/api/tests/logic/user_test.py
+++ b/api/tests/logic/user_test.py
@@ -181,7 +181,7 @@ def test_remove_preferences_removes_on_opt_out(session, subscription):
     session.commit()
 
     assert user.subscription_preferences == [user_pref]
-    updated_preferences = {preference.id: False}
+    updated_preferences = {preference.id: {'enabled': False}}
     removed = remove_preferences(user, updated_preferences, subscription.id)
     assert removed == {user_pref.preference_id}
     user = User.query.filter(User.id == user.id).one()
@@ -231,7 +231,7 @@ def test_remove_preferences_multiple_remove_on_opt_in(session, subscription):
     session.commit()
 
     assert user.subscription_preferences == [user_pref_1, user_pref_2]
-    updated_preferences = {preference_1.id: False, preference_2.id: False}
+    updated_preferences = {preference_1.id: {'enabled': False}, preference_2.id: {'enabled': False}}
     removed = remove_preferences(user, updated_preferences, subscription.id)
     assert removed == {user_pref_1.preference_id, user_pref_2.preference_id}
     user = user = User.query.filter(User.id == user.id).one()

--- a/api/tests/routes/api/v1/preference_test.py
+++ b/api/tests/routes/api/v1/preference_test.py
@@ -32,6 +32,8 @@ def test_preferences_api_user_exists(app, database, fake_user):
                 {
                     'active': True,
                     'date': '2017-01-20T23:00:00+00:00',
+                    # TODO(areilly) Where is this coming from?
+                    'auto_renew': False,
                     'id': database.sub.datetime[0].id
                 }
             ],

--- a/api/tests/routes/api/v1/preference_test.py
+++ b/api/tests/routes/api/v1/preference_test.py
@@ -51,7 +51,7 @@ def test_preference_api_post(monkeypatch, app, database, fake_user):
             '/v1/user/preferences/subscription/{}'.format(sub_key),
             method='POST',
             data=json.dumps({
-                database.sub.datetime[0].id: False,
+                database.sub.datetime[0].id: {'enabled': False, 'autoRenew': False},
                 'email': fake_user.email,
             }),
             content_type='application/json'

--- a/api/yelp_beans/logic/subscription.py
+++ b/api/yelp_beans/logic/subscription.py
@@ -63,7 +63,8 @@ def merge_subscriptions_with_preferences(user):
     user_preferences = [
         {
             'subscription_id': user_subscription.subscription_id,
-            'datetime_id': user_subscription.preference_id
+            'datetime_id': user_subscription.preference_id,
+            'auto_renew': user_subscription.auto_renew
         } for user_subscription in user.subscription_preferences
     ]
     subscriptions = [
@@ -84,6 +85,7 @@ def merge_subscriptions_with_preferences(user):
                 for date in subscription['datetime']:
                     if date['id'] == user_preference['datetime_id']:
                         date['active'] = True
+                        date['auto_renew'] = user_preference['auto_renew']
 
     return subscriptions
 

--- a/api/yelp_beans/logic/user.py
+++ b/api/yelp_beans/logic/user.py
@@ -203,11 +203,12 @@ def add_preferences(user, updated_preferences, subscription_id):
     set(SubscriptionDateTime.id)
     """
     added = set()
-    for datetime_id, active in updated_preferences.items():
-        if active:
+    for datetime_id, status in updated_preferences.items():
+        if status.enabled:
             preference = UserSubscriptionPreferences(
                 subscription_id=subscription_id,
                 preference_id=datetime_id,
+                auto_renew=status.auto_renew
             )
             db.session.add(preference)
             user.subscription_preferences.append(preference)

--- a/api/yelp_beans/logic/user.py
+++ b/api/yelp_beans/logic/user.py
@@ -170,7 +170,7 @@ def remove_preferences(user, updated_preferences, subscription_id):
     Parameters
     ----------
     user - db.User
-    preferences - {SubscriptionDateTime.id:Boolean}
+    preferences - {SubscriptionDateTime.id:{}}
     subscription_id - int
 
     Returns
@@ -181,7 +181,7 @@ def remove_preferences(user, updated_preferences, subscription_id):
     removed = set()
     for preference in user.subscription_preferences:
         if preference.subscription.id == subscription_id:
-            if not updated_preferences.get(preference.preference_id, True):
+            if not updated_preferences.get(preference.preference_id, {}).get('enabled', True):
                 removed.add(preference.preference_id)
                 db.session.delete(preference)
 

--- a/api/yelp_beans/logic/user.py
+++ b/api/yelp_beans/logic/user.py
@@ -195,7 +195,7 @@ def add_preferences(user, updated_preferences, subscription_id):
     Parameters
     ----------
     user - db.User
-    preferences - {SubscriptionDateTime.id:Boolean}
+    preferences - {SubscriptionDateTime.id:{enabled:Boolean, autoRenew:Boolean}
     subscription_id - int
 
     Returns
@@ -204,11 +204,11 @@ def add_preferences(user, updated_preferences, subscription_id):
     """
     added = set()
     for datetime_id, status in updated_preferences.items():
-        if status.enabled:
+        if status['enabled']:
             preference = UserSubscriptionPreferences(
                 subscription_id=subscription_id,
                 preference_id=datetime_id,
-                auto_renew=status.auto_renew
+                auto_renew=status['autoRenew']
             )
             db.session.add(preference)
             user.subscription_preferences.append(preference)

--- a/api/yelp_beans/matching/match_utils.py
+++ b/api/yelp_beans/matching/match_utils.py
@@ -90,5 +90,8 @@ def get_previous_meetings(subscription, cooldown=None):
     return disallowed_meetings
 
 def store_meeting_request(meeting_request):
+    if meeting_request is None:
+        return
+
     db.session.add(meeting_request)
     db.session.commit()

--- a/api/yelp_beans/matching/match_utils.py
+++ b/api/yelp_beans/matching/match_utils.py
@@ -88,3 +88,7 @@ def get_previous_meetings(subscription, cooldown=None):
     disallowed_meetings = {tuple([meeting.id for meeting in meeting]) for meeting in disallowed_meetings}
 
     return disallowed_meetings
+
+def store_meeting_request(meeting_request):
+    db.session.add(meeting_request)
+    db.session.commit()

--- a/api/yelp_beans/models.py
+++ b/api/yelp_beans/models.py
@@ -78,6 +78,7 @@ class UserSubscriptionPreferences(db.Model):
     preference_id = db.Column(db.Integer, db.ForeignKey('subscription_date_time.id'))
     preference = db.relationship('SubscriptionDateTime',
                                  backref='user_subscription_preferences')
+    auto_renew = db.Column(db.Bool)
 
 
 class SubscriptionDateTime(db.Model):

--- a/api/yelp_beans/models.py
+++ b/api/yelp_beans/models.py
@@ -78,7 +78,7 @@ class UserSubscriptionPreferences(db.Model):
     preference_id = db.Column(db.Integer, db.ForeignKey('subscription_date_time.id'))
     preference = db.relationship('SubscriptionDateTime',
                                  backref='user_subscription_preferences')
-    auto_renew = db.Column(db.Bool)
+    auto_renew = db.Column(db.Boolean)
 
 
 class SubscriptionDateTime(db.Model):

--- a/api/yelp_beans/models.py
+++ b/api/yelp_beans/models.py
@@ -78,7 +78,7 @@ class UserSubscriptionPreferences(db.Model):
     preference_id = db.Column(db.Integer, db.ForeignKey('subscription_date_time.id'))
     preference = db.relationship('SubscriptionDateTime',
                                  backref='user_subscription_preferences')
-    auto_renew = db.Column(db.Boolean)
+    auto_renew = db.Column(db.Boolean, nullable=False, default=False)
 
 
 class SubscriptionDateTime(db.Model):

--- a/api/yelp_beans/routes/api/v1/meeting_requests.py
+++ b/api/yelp_beans/routes/api/v1/meeting_requests.py
@@ -31,6 +31,7 @@ def create_delete_meeting_request():
             return 400
         meeting_request = query_meeting_request(meeting_spec, user)
 
+        # if a meeting_request doesn't already exist, then create one in the database
         if not meeting_request:
             meeting_request = MeetingRequest(meeting_spec=meeting_spec, user=user)
             db.session.add(meeting_request)

--- a/api/yelp_beans/routes/tasks.py
+++ b/api/yelp_beans/routes/tasks.py
@@ -39,7 +39,9 @@ def generate_meeting_requests():
     for preference in UserSubscriptionPreferences.query.all():
         logging.info(preference)
         if preference.auto_renew:
-            meeting_spec = filter(lambda spec: spec.meeting_subscription_id == preference.subscription_id, current_specs)[0]
+meeting_specs = filter(lambda spec: spec.meeting_subscription_id == preference.subscription_id, current_specs)
+assert len(meeting_specs) == 1
+meeting_spec = meeting_specs[0]
             meeting_request = MeetingRequest(meeting_spec=meeting_spec, user=preference.user)
             store_meeting_request(meeting_request)
     return 'OK'

--- a/api/yelp_beans/routes/tasks.py
+++ b/api/yelp_beans/routes/tasks.py
@@ -12,6 +12,7 @@ from yelp_beans.logic.user import is_valid_user_subscription_preference
 from yelp_beans.logic.user import sync_employees
 from yelp_beans.matching.match import generate_meetings
 from yelp_beans.matching.match_utils import save_meetings
+from yelp_beans.matching.match_utils import store_meeting_request
 from yelp_beans.models import Meeting
 from yelp_beans.models import MeetingParticipant
 from yelp_beans.models import MeetingRequest
@@ -20,8 +21,6 @@ from yelp_beans.models import UserSubscriptionPreferences
 from yelp_beans.send_email import send_batch_meeting_confirmation_email
 from yelp_beans.send_email import send_batch_unmatched_email
 from yelp_beans.send_email import send_batch_weekly_opt_in_email
-
-from api.yelp_beans.matching.match_utils import store_meeting_request
 
 tasks = Blueprint('tasks', __name__)
 

--- a/api/yelp_beans/routes/tasks.py
+++ b/api/yelp_beans/routes/tasks.py
@@ -38,7 +38,7 @@ def generate_meeting_requests():
     current_specs = get_specs_for_current_week()
     for preference in UserSubscriptionPreferences.query.all():
         logging.info(preference)
-        if preference.auto_renew is True:
+        if preference.auto_renew:
             meeting_spec = filter(lambda spec: spec.meeting_subscription_id == preference.subscription_id, current_specs)[0]
             meeting_request = MeetingRequest(meeting_spec=meeting_spec, user=preference.user)
             store_meeting_request(meeting_request)

--- a/frontend/components/UserPreferenceForm.js
+++ b/frontend/components/UserPreferenceForm.js
@@ -43,7 +43,7 @@ class UserPreferenceForm extends Component {
   handleChange(event) {
     const data = {
       [event.target.value]: {
-        [event.target.id]: {enabled: event.target.checked}
+        [event.target.id]: { enabled: event.target.checked },
       },
     };
     this.setState(data);
@@ -52,7 +52,7 @@ class UserPreferenceForm extends Component {
   handleAutorenewalChange(event) {
     const data = {
       [event.target.value]: {
-        [event.target.id]: {auto_renew: event.target.checked}
+        [event.target.id]: { autoRenew: event.target.checked },
       },
     };
     this.setState(data);
@@ -96,7 +96,8 @@ No Subscription Available.
     if (preference) {
       return preference.datetime.map((datetime) => {
         let checked = datetime.active;
-        let auto_renew = datetime.auto_renew;
+        // TODO(areilly): I don't know what I meant to do here, but I don't think it was this
+        const { autoRenew } = datetime;
         if (state === null) {
             // eslint-disable-line
         } else if (`${preference.id}` in state) {
@@ -113,7 +114,7 @@ No Subscription Available.
             />
             <input
               id={datetime.id}
-              defaultChecked={auto_renew}
+              defaultChecked={autoRenew}
               onChange={this.handleAutorenewalChange}
               value={preference.id}
               type="checkbox"

--- a/frontend/components/UserPreferenceForm.js
+++ b/frontend/components/UserPreferenceForm.js
@@ -96,7 +96,7 @@ No Subscription Available.
     if (preference) {
       return preference.datetime.map((datetime) => {
         let checked = datetime.active;
-        let autoRenew = datetime.auto_renew;
+        const autoRenew = datetime.auto_renew;
         if (state === null) {
             // eslint-disable-line
         } else if (`${preference.id}` in state) {

--- a/frontend/components/UserPreferenceForm.js
+++ b/frontend/components/UserPreferenceForm.js
@@ -43,10 +43,19 @@ class UserPreferenceForm extends Component {
   handleChange(event) {
     const data = {
       [event.target.value]: {
-        [event.target.id]: event.target.checked,
+        [event.target.id]: {enabled: event.target.checked}
       },
     };
-    this.setState((prevState) => ({ ...prevState, ...data }));
+    this.setState(data);
+  }
+
+  handleAutorenewalChange(event) {
+    const data = {
+      [event.target.value]: {
+        [event.target.id]: {auto_renew: event.target.checked}
+      },
+    };
+    this.setState(data);
   }
 
   renderPreferences(state) {
@@ -87,6 +96,7 @@ No Subscription Available.
     if (preference) {
       return preference.datetime.map((datetime) => {
         let checked = datetime.active;
+        let auto_renew = datetime.auto_renew;
         if (state === null) {
             // eslint-disable-line
         } else if (`${preference.id}` in state) {
@@ -98,6 +108,13 @@ No Subscription Available.
               id={datetime.id}
               defaultChecked={checked}
               onChange={this.handleChange}
+              value={preference.id}
+              type="checkbox"
+            />
+            <input
+              id={datetime.id}
+              defaultChecked={auto_renew}
+              onChange={this.handleAutorenewalChange}
               value={preference.id}
               type="checkbox"
             />

--- a/frontend/components/UserPreferenceForm.js
+++ b/frontend/components/UserPreferenceForm.js
@@ -96,8 +96,7 @@ No Subscription Available.
     if (preference) {
       return preference.datetime.map((datetime) => {
         let checked = datetime.active;
-        // TODO(areilly): I don't know what I meant to do here, but I don't think it was this
-        const { autoRenew } = datetime;
+        let autoRenew = datetime.auto_renew;
         if (state === null) {
             // eslint-disable-line
         } else if (`${preference.id}` in state) {

--- a/frontend/tests/components/UserPreferenceForm.spec.js
+++ b/frontend/tests/components/UserPreferenceForm.spec.js
@@ -1,20 +1,32 @@
-// import React from 'react';
-// import renderer from 'react-test-renderer';
+import React from 'react';
+import renderer from 'react-test-renderer';
 
-// import UserPreferenceForm from '../../components/UserPreferenceForm';
+import UserPreferenceForm from '../../components/UserPreferenceForm';
 
 
 describe('UserPreferenceForm', () => {
   it('is rendered with one subscription', () => {
-    // const metric = { title: 'weekly', total_subscribed: 10, week_participants: 20 };
-    // const component = renderer.create(<MetricsListItem metric={metric} />);
-    // expect(component.toJSON()).toMatchSnapshot();
-    expect(true);
+    const preferences = [
+      {
+        "datetime":[
+          {
+            "active":true,
+            "auto_renew":false,
+            "date":"2021-03-25T22:00:00+00:00",
+            "id":27
+          }
+        ],
+        "id":20,
+        "location":"Online",
+        "office":"Remote",
+        "rule_logic":"any",
+        "size":2,
+        "timezone":"America/Los_Angeles",
+        "title":"iOS Weekly (all offices welcome, please set up your own time/place)"
+      }
+    ];
+    const component = renderer.create(<UserPreferenceForm preferences={preferences} email="test@gmail.com" />);
+    const json = component.toJSON()
+    expect(json).toMatchSnapshot();
   });
-
-//   it('is rendered with many subscriptions', () => {
-//     const metric = { title: 'monthly', total_subscribed: 2, week_participants: 4 };
-//     const component = renderer.create(<MetricsListItem metric={metric} />);
-//     expect(component.toJSON()).toMatchSnapshot();
-//   });
 });

--- a/frontend/tests/components/UserPreferenceForm.spec.js
+++ b/frontend/tests/components/UserPreferenceForm.spec.js
@@ -1,0 +1,20 @@
+// import React from 'react';
+// import renderer from 'react-test-renderer';
+
+// import UserPreferenceForm from '../../components/UserPreferenceForm';
+
+
+describe('UserPreferenceForm', () => {
+  it('is rendered with one subscription', () => {
+    // const metric = { title: 'weekly', total_subscribed: 10, week_participants: 20 };
+    // const component = renderer.create(<MetricsListItem metric={metric} />);
+    // expect(component.toJSON()).toMatchSnapshot();
+    expect(true);
+  });
+
+//   it('is rendered with many subscriptions', () => {
+//     const metric = { title: 'monthly', total_subscribed: 2, week_participants: 4 };
+//     const component = renderer.create(<MetricsListItem metric={metric} />);
+//     expect(component.toJSON()).toMatchSnapshot();
+//   });
+});

--- a/frontend/tests/components/UserPreferenceForm.spec.js
+++ b/frontend/tests/components/UserPreferenceForm.spec.js
@@ -28,5 +28,6 @@ describe('UserPreferenceForm', () => {
     const component = renderer.create(<UserPreferenceForm preferences={preferences} email="test@gmail.com" />);
     const json = component.toJSON()
     expect(json).toMatchSnapshot();
+    expect(true);
   });
 });

--- a/frontend/tests/components/__snapshots__/UserPreferenceForm.spec.js.snap
+++ b/frontend/tests/components/__snapshots__/UserPreferenceForm.spec.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UserPreferenceForm is rendered with one subscription 1`] = `
+<div>
+  <div>
+    <h3>
+      iOS Weekly (all offices welcome, please set up your own time/place)
+    </h3>
+    <h6>
+      Remote
+      ,
+
+      Online
+
+      (
+      2
+      )
+    </h6>
+    <div>
+      <label
+        htmlFor={27}
+      >
+        <input
+          defaultChecked={true}
+          id={27}
+          onChange={[Function]}
+          type="checkbox"
+          value={20}
+        />
+        <input
+          defaultChecked={false}
+          id={27}
+          onChange={[Function]}
+          type="checkbox"
+          value={20}
+        />
+        Thursday 3:00 PM PDT
+      </label>
+      <button
+        className="btn btn-danger left30"
+        onClick={[Function]}
+        type="button"
+      >
+        Set Preferences!
+      </button>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
- [x] cron job
- [x] task creates MeetingRequests
- [x] migration to add auto_renewal column to UserSubscriptionPreferences
- [x] test the whole shebang
- [x] add a second checkbox to give users the option to auto renew
- [ ] update match emails to let users know that they've been matched because they have their preferences set to auto renew

Other things that are happening in this PR:
- [Alembic](https://alembic.sqlalchemy.org/en/latest/) is being introduced to handle migrations
  -  you can run migrations with `alembic upgrade head` from `api`