### PR TITLE
Introduce the downstream pre-commit hook to help us keep docs up to date

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,7 @@ repos:
         args: ['--baseline', '.secrets.baseline']
         exclude: .*tests/.*|.*yelp/testing/.*|\.pre-commit-config\.yaml|package-lock\.json|.*.html
         language_version: python3.8
+- repo: https://github.com/twof/Downstream
+  rev: 0.1.0
+  hooks:
+    - id: downstream

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ $(shell node -p "require('./frontend/lib/config.json').$(1)")
 endef
 
 PROJECT := $(call GetFromPkg,PROJECT)
-a
+
 
 .PHONY: deploy
 deploy: deploy_services deploy_dispatch

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ $(shell node -p "require('./frontend/lib/config.json').$(1)")
 endef
 
 PROJECT := $(call GetFromPkg,PROJECT)
-
+a
 
 .PHONY: deploy
 deploy: deploy_services deploy_dispatch

--- a/api/downsteam.yml
+++ b/api/downsteam.yml
@@ -1,0 +1,4 @@
+associations:
+  Makefile:
+    - https://github.com/Yelp/beans/wiki/Getting-Started
+    - https://github.com/Yelp/beans/wiki/Contributing

--- a/downstream.yml
+++ b/downstream.yml
@@ -1,0 +1,4 @@
+associations:
+  Makefile:
+    - https://github.com/Yelp/beans/wiki/Getting-Started
+    - https://github.com/Yelp/beans/wiki/Contributing

--- a/frontend/downstream.yml
+++ b/frontend/downstream.yml
@@ -1,0 +1,4 @@
+associations:
+  Makefile:
+    - https://github.com/Yelp/beans/wiki/Getting-Started
+    - https://github.com/Yelp/beans/wiki/Contributing


### PR DESCRIPTION
Example pre-commit output:

```
$ git commit -am "added downstream"
Trim Trailing Whitespace.................................................Passed
Fix End of Files.........................................................Passed
Check JSON...........................................(no files to check)Skipped
Check Yaml...........................................(no files to check)Skipped
Debug Statements (Python)............................(no files to check)Skipped
Tests should end in _test.py.........................(no files to check)Skipped
Fix requirements.txt.................................(no files to check)Skipped
Fix python encoding pragma...........................(no files to check)Skipped
check BOM - deprecated: use fix-byte-order-marker........................Passed
Check for merge conflicts................................................Passed
fix UTF-8 byte order marker..............................................Passed
flake8...............................................(no files to check)Skipped
Reorder python imports...............................(no files to check)Skipped
Detect secrets...........................................................Passed
Downstream...............................................................Passed
- hook id: downstream
- duration: 0.02s

Due to changes made to Makefile, you may need to make updates to the following:
 https://github.com/Yelp/beans/wiki/Getting-Started
https://github.com/Yelp/beans/wiki/Contributing
```

See the downstream project for more info about usage. We could also add a github action so necessary doc updates are reported in PR comments.

https://github.com/twof/downstream