### PR TITLE
Issue #145: Make calendar link timezone aware

### DIFF
--- a/api/yelp_beans/send_email.py
+++ b/api/yelp_beans/send_email.py
@@ -183,6 +183,14 @@ def create_google_calendar_invitation_link(user_list, title, office, location, m
         'location': office + " " + location,
         'add': ','.join([user.email for user in user_list])
     }
+    try:
+        if meeting_datetime.strftime("%Z") and "ctz" not in url_params:
+            # If the meeting time have a timezone specified
+            # and Calendar URL link doesn't contain timezone
+            # Add the "ctz" parameter to Google's Calendar template link
+            url_params["ctz"] = meeting_datetime.tzinfo.zone
+    except Exception:
+        logging.exception("Failed to add timezone information to Google Calendar link")
     invite_url += urllib.parse.urlencode(url_params)
     return invite_url
 

--- a/api/yelp_beans/send_email.py
+++ b/api/yelp_beans/send_email.py
@@ -183,14 +183,12 @@ def create_google_calendar_invitation_link(user_list, title, office, location, m
         'location': office + " " + location,
         'add': ','.join([user.email for user in user_list])
     }
-    try:
-        if meeting_datetime.strftime("%Z") and "ctz" not in url_params:
-            # If the meeting time have a timezone specified
-            # and Calendar URL link doesn't contain timezone
-            # Add the "ctz" parameter to Google's Calendar template link
-            url_params["ctz"] = meeting_datetime.tzinfo.zone
-    except Exception:
-        logging.exception("Failed to add timezone information to Google Calendar link")
+    if meeting_datetime.tzinfo and meeting_datetime.tzinfo.zone and "ctz" not in url_params:
+        # If the meeting time have a timezone specified
+        # and Calendar URL link doesn't contain timezone
+        # Add the "ctz" parameter to Google's Calendar template link
+        url_params["ctz"] = meeting_datetime.tzinfo.zone
+
     invite_url += urllib.parse.urlencode(url_params)
     return invite_url
 

--- a/api/yelp_beans/send_email.py
+++ b/api/yelp_beans/send_email.py
@@ -183,7 +183,7 @@ def create_google_calendar_invitation_link(user_list, title, office, location, m
         'location': office + " " + location,
         'add': ','.join([user.email for user in user_list])
     }
-    if meeting_datetime.tzinfo and meeting_datetime.tzinfo.zone and "ctz" not in url_params:
+    if meeting_datetime.tzinfo and meeting_datetime.tzinfo.zone:
         # If the meeting time have a timezone specified
         # and Calendar URL link doesn't contain timezone
         # Add the "ctz" parameter to Google's Calendar template link


### PR DESCRIPTION
Google's Calendar invite link takes **ctz** parameter as the timezone information (e.g. "America/Los_Angeles")

From past Yelp Beans match email, it seems that we already have the timezone information in the **meeting_datetime** object. We just need to add the information to the Google Calendar link.