### PR TITLE
Add settings for codespaces environment 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+ARG VARIANT="jammy"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+        | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+        && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+        && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+        && apt-get -y install --no-install-recommends fish google-cloud-cli vim

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": { "VARIANT": "ubuntu-22.04" }
+	},
+
+	"forwardPorts": [5000, 8080],
+
+	"remoteUser": "vscode",
+	"features": {
+		"sshd": "latest",
+		"node": "lts",
+		"python": "3.8"
+	}
+}


### PR DESCRIPTION
This adds a dockerfile for the codespaces environment and some
additional configuration for it.

I was able to start both the frontend and the backend successfully.

Issues with using codespaces:
- Swift isn't installed so the swift based pre-commit hook isn't working
- ~Accessing the frontend via the github url has issues because the /auth path is used by github to authenticate who is accessing the forwarded port. This collides with our /auth/google path~. Seems to be hitting the node server now, but still can't auth because you can't set a redirect url in appengine to point at github.dev (that is what I am guessing based on the error message).
- Codespaces are supposed to be somewhat short lived (expire after 30 days by default). This is somewhat annoying since you need to copy in your config every time you start it up.

I will do some addition prs to try and address these issues, but this should be a good starting point.
