### PR TITLE
Add better default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ endef
 
 PROJECT := $(call GetFromPkg,PROJECT)
 
+.PHONY: all
+all: development
 
 .PHONY: deploy
 deploy: deploy_services deploy_dispatch


### PR DESCRIPTION
Make will default to the first target in the file if one isn't specified
at the command line. For the Makefile at the root of the repo that was
the deploy target which is not what we want. This makes it be the
development target instead. The Makefiles in frontend and api already
have this setup.