### PR TITLE
Use pathname instead of href when extracting meeting spec key

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         language_version: python3.8
     -   id: fix-byte-order-marker
         language_version: python3.8
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.8.4
     hooks:
     -   id: flake8

--- a/frontend/containers/MeetingRequest.js
+++ b/frontend/containers/MeetingRequest.js
@@ -19,11 +19,7 @@ class MeetingRequest extends Component {
   }
 
   static getMeetingSpecKey() {
-    const path = window.location.href.split('/');
-    // Remove any get parameters
-    if (path[path.length - 1].indexOf('?') > -1) {
-      return path[path.length - 1].substring(0, path[path.length - 1].indexOf('?'));
-    }
+    const path = window.location.pathname.split('/');
     return path[path.length - 1];
   }
 


### PR DESCRIPTION
The pathname variable doesn't include the query parameters or the fragment. Currently if the url had a fragment then it was included in the returned meeting spec key and then caused an error on the backend.

Manually tested this in my browser and it worked.