### PR TITLE
Add script to allow loading config files from env var

### DIFF
--- a/.devcontainer/configs_in_env.py
+++ b/.devcontainer/configs_in_env.py
@@ -1,0 +1,70 @@
+import gzip
+import json
+import os
+import subprocess
+from argparse import ArgumentParser
+from base64 import b64decode
+from base64 import b64encode
+from pathlib import Path
+
+CONFIG_FILES = (
+    "api/client_secrets.json",
+    "api/config.yaml",
+    "frontend/lib/config.json",
+)
+BEANS_CONFIG_ENV = 'YELP_BEANS_CONFIG'
+
+
+def create_parser() -> ArgumentParser:
+    parser = ArgumentParser()
+    parser.add_argument('action', choices=('print', 'load_from_env'))
+    return parser
+
+
+def get_git_root() -> Path:
+    res = subprocess.run(
+        ('git', 'rev-parse', '--show-toplevel'),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(res.stdout.strip())
+
+
+def print_config_as_str() -> None:
+    git_root = get_git_root()
+    configs = {}
+    for config_filepath in CONFIG_FILES:
+        config_file = git_root / config_filepath
+        configs[config_filepath] = config_file.read_text()
+
+    configs_as_str = json.dumps(configs)
+    print(b64encode(gzip.compress(configs_as_str.encode())).decode())
+
+
+def load_config_from_env() -> None:
+    if BEANS_CONFIG_ENV not in os.environ:
+        print(f'{BEANS_CONFIG_ENV} not in the environment. Not writing configs')
+        return
+
+    git_root = get_git_root()
+    configs_as_str = gzip.decompress(b64decode(os.environ[BEANS_CONFIG_ENV]))
+    configs = json.loads(configs_as_str)
+
+    for config_filepath, config in configs.items():
+        config_file = git_root / config_filepath
+        config_file.write_text(config)
+
+
+def main():
+    args = create_parser().parse_args()
+    if args.action == 'print':
+        print_config_as_str()
+    elif args.action == 'load_from_env':
+        load_config_from_env()
+    else:
+        raise ValueError("Unsupported action")
+
+
+if __name__ == '__main__':
+    main()

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,8 @@
 
 	"forwardPorts": [5000, 8080],
 
+	"postCreateCommand": "python .devcontainer/configs_in_env.py load_from_env",
+
 	"remoteUser": "vscode",
 	"features": {
 		"sshd": "latest",


### PR DESCRIPTION
If you are using codespaces to develop beans then you have to copy your config files into the codespaces every time you create a new one. To make the config files automatically get created, I created a script that converts the config files into a single string and writes them from that string. You can then add this string as a Github Codespaces Secret with the name YELP_BEANS_CONFIG. The added postCreateCommand will be ran automatically after the codespace is created and will write the config files.

I tested this by running the print command and adding the result as a secret. I then launched a new codespace based on this branch and the config files were written when I attached to the codespace.