### PR TITLE
Create read-only version of edit subscription page

### DIFF
--- a/api/tests/routes/api/v1/subscriptions_test.py
+++ b/api/tests/routes/api/v1/subscriptions_test.py
@@ -117,3 +117,35 @@ def test_get_subscriptions_has_rule(client, session):
             'timezone': 'America/Los_Angeles',
         },
     ]
+
+
+def test_get_subscription(client, session):
+    preference = SubscriptionDateTime(datetime=datetime(2017, 7, 20, 13, 0))
+    session.add(preference)
+    rule = Rule(name='field', value='value')
+    session.add(rule)
+    subscription = MeetingSubscription(
+        timezone='America/Los_Angeles',
+        datetime=[preference],
+        title="Test",
+        size=2,
+        office='tester',
+        location='test place',
+        rule_logic='all',
+        user_rules=[rule],
+    )
+    session.add(subscription)
+    session.commit()
+
+    resp = client.get(f'v1/subscriptions/{subscription.id}')
+    assert resp.json == {
+        'id': subscription.id,
+        'location': 'test place',
+        'name': "Test",
+        'office': 'tester',
+        'rule_logic': 'all',
+        'rules': [{'field': 'field', 'value': 'value'}],
+        'size': 2,
+        'time_slots': [{'day': 'thursday', 'hour': 13, 'minute': 0}],
+        'timezone': 'America/Los_Angeles',
+    }

--- a/api/yelp_beans/routes/api/v1/subscriptions.py
+++ b/api/yelp_beans/routes/api/v1/subscriptions.py
@@ -156,3 +156,13 @@ def get_subscriptions():
     resp = jsonify([json.loads(spec.json()) for spec in specs])
     resp.status_code = 200
     return resp
+
+
+@subscriptions_blueprint.route('/<int:sub_id>', methods=["GET"])
+def get_subscription(sub_id: int):
+    sub_model = MeetingSubscription.query.filter(MeetingSubscription.id == sub_id).one()
+    sub = Subscription.from_sqlalchemy(sub_model)
+    # There is probably a better way to do this, but not sure what it is yet
+    resp = jsonify(json.loads(sub.json()))
+    resp.status_code = 200
+    return resp

--- a/frontend/components/Footer.js
+++ b/frontend/components/Footer.js
@@ -6,7 +6,7 @@ const Footer = () => (
     <hr className="footer_hr" />
     <div className="container">
       <div className="row">
-        <div className="col-lg-8 col-lg-offset-2 text-center">
+        <div className="w-100 text-center">
           <h5>
             <small>
 Made with ♥ at Yelp.

--- a/frontend/components/Header.js
+++ b/frontend/components/Header.js
@@ -2,17 +2,18 @@ import React from 'react';
 
 
 const Header = () => (
-  <nav className="navbar">
-    <img
-      className="logo"
-      alt="Beans Logo"
-      src="/img/beans-white.svg"
-    />
-    <span className="logo-font">
-Beans
+  <nav className="navbar mb-3">
+    <span>
+      <img
+        className="logo"
+        alt="Beans Logo"
+        src="/img/beans-white.svg"
+      />
+      <span className="logo-font">
+  Beans
+      </span>
     </span>
     <img
-      className="yelp_logo"
       alt="Yelp Logo"
       src="https://s3-media3.fl.yelpcdn.com/assets/srv0/styleguide/b62d62e8722a/assets/img/brand_guidelines/yelp_fullcolor_outline@2x.png"
     />

--- a/frontend/containers/Subscription.js
+++ b/frontend/containers/Subscription.js
@@ -13,8 +13,8 @@ const DAYS_OF_THE_WEEK = [
 ];
 
 const RULE_LOGIC_OPTIONS = [
-  { label: 'All', value: 'all' },
-  { label: 'Any', value: 'any' },
+  { label: 'all rules', value: 'all' },
+  { label: 'at least one rule', value: 'any' },
 ];
 
 const RuleShape = PropTypes.shape({
@@ -108,7 +108,7 @@ const RulesField = ({ rules, ruleLogic }) => (
     <h3>Rules</h3>
     <div className="form-row mt-2">
       <label htmlFor="rule-logic" className="col-form-label">
-        Rule Logic:
+        Must match
       </label>
       <div className="col-auto">
         <select className="form-control" id="rule-logic" disabled={rules.length <= 1}>

--- a/frontend/containers/Subscription.js
+++ b/frontend/containers/Subscription.js
@@ -1,0 +1,237 @@
+import axios from 'axios';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const DAYS_OF_THE_WEEK = [
+  { label: 'Sunday', value: 'sunday' },
+  { label: 'Monday', value: 'monday' },
+  { label: 'Tuesday', value: 'tuesday' },
+  { label: 'Wednesday', value: 'wednesday' },
+  { label: 'Thursday', value: 'thursday' },
+  { label: 'Friday', value: 'friday' },
+  { label: 'Saturday', value: 'saturday' },
+];
+
+const RULE_LOGIC_OPTIONS = [
+  { label: 'All', value: 'all' },
+  { label: 'Any', value: 'any' },
+];
+
+const RuleShape = PropTypes.shape({
+  field: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+});
+const TimeSlotShape = PropTypes.shape({
+  day: PropTypes.string.isRequired,
+  hour: PropTypes.number.isRequired,
+  minute: PropTypes.number.isRequired,
+});
+
+const getSubscriptionId = () => {
+  const path = window.location.pathname.split('/');
+  return path[path.length - 1];
+};
+
+const StringField = ({
+  field, label, value, inputClassName,
+}) => (
+  <div className="form-group">
+    <label htmlFor={field}>
+      {label}
+    </label>
+    <input type="text" className={`form-control ${inputClassName}`} id={field} value={value} required />
+  </div>
+);
+
+StringField.propTypes = {
+  field: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  inputClassName: PropTypes.string,
+};
+
+StringField.defaultProps = {
+  inputClassName: '',
+};
+
+const NumberField = ({ field, label, value }) => (
+  <div className="form-group">
+    <label htmlFor={field}>
+      {label}
+    </label>
+    <input type="number" className="form-control" id={field} value={value} required />
+  </div>
+);
+
+NumberField.propTypes = {
+  field: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.number.isRequired,
+};
+
+const RuleField = ({ rule, index }) => {
+  const ruleFieldId = `rule-${index}-field`;
+  const ruleValueId = `rule-${index}-value`;
+  // I can't figure out how to make this pass and they do have an related control
+  /* eslint-disable jsx-a11y/label-has-associated-control */
+  return (
+    <div className="form-row mt-2">
+      <label htmlFor={ruleFieldId} className="col-form-label">
+        Field:
+      </label>
+      <div className="col">
+        <input type="text" className="form-control" id={ruleFieldId} value={rule.field} required />
+      </div>
+      <label htmlFor={ruleValueId} className="col-form-label">
+        Value:
+      </label>
+      <div className="col">
+        <input type="text" className="form-control" id={ruleValueId} value={rule.value} required />
+      </div>
+      <div className="col-auto">
+        <button type="button" className="btn btn-outline-danger btn-sm mt-1">Remove</button>
+      </div>
+    </div>
+  );
+  /* eslint-enable jsx-a11y/label-has-associated-control */
+};
+
+RuleField.propTypes = {
+  rule: RuleShape.isRequired,
+  index: PropTypes.number.isRequired,
+};
+
+// I can't figure out how to make this pass and they do have an related control
+/* eslint-disable jsx-a11y/label-has-associated-control */
+const RulesField = ({ rules, ruleLogic }) => (
+  <div className="form-group">
+    <h3>Rules</h3>
+    <div className="form-row mt-2">
+      <label htmlFor="rule-logic" className="col-form-label">
+        Rule Logic:
+      </label>
+      <div className="col-auto">
+        <select className="form-control" id="rule-logic" disabled={rules.length <= 1}>
+          <option value="no-rule-logic" select={ruleLogic == null}>Select a rule logic</option>
+          {RULE_LOGIC_OPTIONS.map((ruleLogicOption) => (
+            <option value={ruleLogicOption.value} selected={ruleLogicOption.value === ruleLogic}>
+              {ruleLogicOption.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+    <div className="form-group mt-2">
+      {rules.map((rule, index) => <RuleField rule={rule} index={index} />)}
+      <button type="button" className="btn btn-secondary btn-sm mt-2">Add Rule</button>
+    </div>
+  </div>
+);
+  /* eslint-enable jsx-a11y/label-has-associated-control */
+
+RulesField.propTypes = {
+  rules: PropTypes.arrayOf(RuleShape).isRequired,
+  ruleLogic: PropTypes.string,
+};
+RulesField.defaultProps = {
+  ruleLogic: null,
+};
+
+const formatTime = (hour, minute) => {
+  const paddedHour = hour.toString().padStart(2, '0');
+  const paddedMinute = minute.toString().padStart(2, '0');
+  return `${paddedHour}:${paddedMinute}`;
+};
+
+const TimeSlotField = ({ timeSlot, index }) => {
+  const dayId = `timeSlot-${index}-day`;
+  const timeId = `timeSlot-${index}-time`;
+  // I can't figure out how to make this pass and they do have an related control
+  /* eslint-disable jsx-a11y/label-has-associated-control */
+  return (
+    <div className="form-row mt-2">
+      <label htmlFor={dayId} className="col-form-label">
+        Day of Week:
+      </label>
+      <div className="col-auto">
+        <select className="form-control" id={dayId}>
+          {DAYS_OF_THE_WEEK.map((day) => (
+            <option value={day.value} selected={day.value === timeSlot.day}>{day.label}</option>
+          ))}
+        </select>
+      </div>
+      <label htmlFor={timeId} className="col-form-label">
+        Time:
+      </label>
+      <div className="col-auto">
+        <input
+          type="text"
+          className="form-control"
+          id={timeId}
+          value={formatTime(timeSlot.hour, timeSlot.minute)}
+          required
+        />
+      </div>
+      <div className="col-auto">
+        <button type="button" className="btn btn-outline-danger btn-sm mt-1">Remove</button>
+      </div>
+    </div>
+  );
+  /* eslint-enable jsx-a11y/label-has-associated-control */
+};
+
+TimeSlotField.propTypes = {
+  timeSlot: TimeSlotShape.isRequired,
+  index: PropTypes.number.isRequired,
+};
+
+const TimeSlotsField = ({ timeSlots, timezone }) => (
+  <div className="form-group">
+    <h3>Meeting Times</h3>
+    <StringField inputClassName="subscription-time-zone-input" field="timezone" label="Time Zone" value={timezone} />
+    <div className="form-group mt-2">
+      {timeSlots.map((timeSlot, index) => <TimeSlotField timeSlot={timeSlot} index={index} />)}
+      <button type="button" className="btn btn-secondary btn-sm mt-2">Add Time Slot</button>
+    </div>
+  </div>
+);
+
+TimeSlotsField.propTypes = {
+  timeSlots: PropTypes.arrayOf(TimeSlotShape).isRequired,
+  timezone: PropTypes.string.isRequired,
+};
+
+const Subscription = () => {
+  const [subscription, setSubscription] = React.useState(null);
+  React.useEffect(() => {
+    axios.get(`/v1/subscriptions/${getSubscriptionId()}`).then(
+      (res) => { setSubscription(res.data); },
+    );
+  }, []);
+
+  if (subscription == null) {
+    return '';
+  }
+
+  return (
+    <div className="container mt-2">
+      <StringField field="name" label="Name" value={subscription.name} />
+      <div className="form-row">
+        <div className="col">
+          <StringField field="location" label="Location" value={subscription.location} />
+        </div>
+        <div className="col">
+          <StringField field="office" label="Office" value={subscription.office} />
+        </div>
+        <div className="col-2">
+          <NumberField field="size" label="Size" value={subscription.size} />
+        </div>
+      </div>
+      <RulesField rules={subscription.rules} ruleLogic={subscription.rule_logic} />
+      <TimeSlotsField timeSlots={subscription.time_slots} timezone={subscription.timezone} />
+      <button type="button" className="btn btn-primary mt-2">Update</button>
+    </div>
+  );
+};
+
+export default Subscription;

--- a/frontend/containers/SubscriptionsList.js
+++ b/frontend/containers/SubscriptionsList.js
@@ -44,6 +44,7 @@ const SubscriptionList = () => {
             <th>Rules</th>
             <th>Time Zone</th>
             <th>Time Slots</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -57,6 +58,7 @@ const SubscriptionList = () => {
               <td><Rules rules={sub.rules} ruleLogic={sub.rule_logic} /></td>
               <td>{sub.timezone}</td>
               <td><TimeSlots timeSlots={sub.time_slots} /></td>
+              <td><a href={`/admin/subscriptions/${sub.id}`}>edit</a></td>
             </tr>
           ))}
         </tbody>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,7 +20,7 @@
     <title>Beans Preferences</title>
 
     <link href="https://fonts.googleapis.com/css?family=Open+Sans|Pacifico" rel="stylesheet">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="/css/style.css"/>
     <link rel='shortcut icon' href='/img/favicon.ico' type='/img/x-icon'/>
 </head>
@@ -28,5 +28,7 @@
 <body>
     <div id="container"/>
     <script type="text/javascript" src="/bundle/app.bundle.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.5.1/dist/jquery.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -12,6 +12,7 @@ import MetricsList from './containers/MetricsList';
 import MeetingRequest from './containers/MeetingRequest';
 import User from './containers/User';
 import SubscriptionsList from './containers/SubscriptionsList';
+import Subscription from './containers/Subscription';
 
 ReactDOM.render(
   <Router>
@@ -21,7 +22,8 @@ ReactDOM.render(
       <Route path="/dashboard" component={MetricsList} />
       <Route path="/user/:email" component={User} />
       <Route path="/meeting_request/:id" component={MeetingRequest} />
-      <Route path="/admin/subscriptions" component={SubscriptionsList} />
+      <Route path="/admin/subscriptions/:id" component={Subscription} />
+      <Route exact path="/admin/subscriptions" component={SubscriptionsList} />
       <Footer />
     </div>
   </Router>,

--- a/frontend/routes.js
+++ b/frontend/routes.js
@@ -5,6 +5,7 @@ import MetricsList from './containers/MetricsList';
 import MeetingRequest from './containers/MeetingRequest';
 import User from './containers/User';
 import SubscriptionsList from './containers/SubscriptionsList';
+import Subscription from './containers/Subscription';
 import App from './App';
 
 
@@ -14,6 +15,7 @@ export default (
     <Route path="/dashboard" component={MetricsList} />
     <Route path="/user/:email" component={User} />
     <Route path="/meeting_request/:id" component={MeetingRequest} />
+    <Route path="/admin/subscriptions/:id" component={Subscription} />
     <Route path="/admin/subscriptions" component={SubscriptionsList} />
   </Route>
 );

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -10,11 +10,6 @@ input[type='radio'], input[type='checkbox'] {
     margin-left: 30px;
 }
 
-.yelp_logo {
-    position: absolute;
-    right: 0px;
-}
-
 .logo {
     width: 6em;
     padding-left: 1em;

--- a/frontend/static/css/style.css
+++ b/frontend/static/css/style.css
@@ -53,3 +53,7 @@ input[type='radio'], input[type='checkbox'] {
 .github-img{
     height: 30px;
 }
+
+.subscription-time-zone-input {
+    max-width: 50ch;
+}

--- a/frontend/webapp.js
+++ b/frontend/webapp.js
@@ -63,6 +63,10 @@ app.get('/admin/subscriptions', (req, res) => {
   res.sendFile(`${__dirname}/index.html`);
 });
 
+app.get('/admin/subscriptions/:id', (req, res) => {
+  res.sendFile(`${__dirname}/index.html`);
+});
+
 app.get('/email', (req, res) => {
   res.send({ email: req.user });
 });


### PR DESCRIPTION
This is the first part of creating an edit page for subscriptions. This is currently a read-only version of the page, so that we can decide how we want it to look and function before adding all the interactivity. I bumped bootstrap a major version, so that we I could use its form components. It says it is backwards compatible, but it did break a couple things. I double checked all the pages and they looked good after my fixes.

<details>
<summary>Pics</summary>

![image](https://user-images.githubusercontent.com/2313879/218204779-2541cd22-d29c-427c-9776-af5681bc05fb.png)

![image](https://user-images.githubusercontent.com/2313879/218204903-5b5fad1b-8ef1-4071-ae5e-6793256a0b48.png)

</details>
