### PR TITLE
Remove downstream pre-commit hook and add script to test dev environment

### DIFF
--- a/.devcontainer/test_dev_env.sh
+++ b/.devcontainer/test_dev_env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -exo pipefail
+
+# This is the config we have in the wiki encoded by configs_from_env
+DEFAULT_CONFIG="H4sIAH9rQGQC/3WRUW+CMBSF/wrpiy9Ctz3yhtBsTKMG4WFZl6bAlXTiraPdzG\
+L87wOJRjS7T037nXPvPT0QuVO0qBWgFQaKBqzxPo1G4jvkwNHpipMVm0fPSRyJYBmLKXvj7TMnnIzv\
+ie7AkjPA8ciRjJ2+jca1qrxfua07e9d1OW4BrMJKFFrXpd6j2ANsjO88PnCMgjSYBCsmsmQmlski8p\
+2R+aqVBZ+2tdfNxuxkAYbmINFQr1KWKlxrWkorc2nA6/ERx+5G7Br9o0poWv/3j36udaPRApa0Vvl5\
+wJv9OVkEWfryJMJZzOapiKN2O05OPV0Lxrp9fq4qL4ncalYsTFj6j67P/UobzhZZJCZZOD1pnIEo/y\
+42A/riPeTuXNsEX1l4B54/6fgHlibBbwwCAAA="
+
+YELP_BEANS_CONFIG=$DEFAULT_CONFIG python3.10 .devcontainer/configs_in_env.py load_from_env
+
+# TODO: Make it so we don't need the NODE_OPTIONS
+NODE_OPTIONS="--openssl-legacy-provider" make development
+
+# Test API
+pushd api
+make serve &
+# Give time for the server to start
+sleep 20
+curl 'http://localhost:5000/'
+popd
+
+# Test Frontend
+pushd frontend
+make serve &
+# Give time for the server to start
+sleep 30
+curl 'http://localhost:8080'
+popd
+
+api/venv/bin/pre-commit run --all-files

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,3 +36,14 @@ jobs:
           node-version: 14.x
       - name: Run tests
         run: make test
+  environment_tests:
+    name: Devenv Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install devcontainer cli
+        run: npm install -g @devcontainers/cli
+      - name: Build and start container
+        run: devcontainer up --workspace-folder .
+      - name: Test developer workflow
+        run: devcontainer exec --workspace-folder . .devcontainer/test_dev_env.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,3 @@ repos:
         args: ['--baseline', '.secrets.baseline']
         exclude: .*tests/.*|.*yelp/testing/.*|\.pre-commit-config\.yaml|package-lock\.json|.*.html
         language_version: python3.8
-- repo: https://github.com/twof/Downstream
-  rev: 0.1.0
-  hooks:
-    - id: downstream

--- a/api/downsteam.yml
+++ b/api/downsteam.yml
@@ -1,4 +1,0 @@
-associations:
-  Makefile:
-    - https://github.com/Yelp/beans/wiki/Getting-Started
-    - https://github.com/Yelp/beans/wiki/Contributing

--- a/downstream.yml
+++ b/downstream.yml
@@ -1,4 +1,0 @@
-associations:
-  Makefile:
-    - https://github.com/Yelp/beans/wiki/Getting-Started
-    - https://github.com/Yelp/beans/wiki/Contributing

--- a/frontend/downstream.yml
+++ b/frontend/downstream.yml
@@ -1,4 +1,0 @@
-associations:
-  Makefile:
-    - https://github.com/Yelp/beans/wiki/Getting-Started
-    - https://github.com/Yelp/beans/wiki/Contributing


### PR DESCRIPTION
This requires swift to run and it doesn't seem worth figuring out how to
install swift in the codespaces environment to have this hook. We added
this to ensure that people update the docs when they change the
makefiles. To ensure that we don't break that this adds a script that tests
that the codespaces devcontainer works. It takes the steps we have in the
wiki and runs them in the docker container and then tests that the flask and
node servers run and that pre-commit works.