### PR TITLE
Add loading spinners to meeting request and user preference pages

### DIFF
--- a/frontend/components/UserPreferenceForm.js
+++ b/frontend/components/UserPreferenceForm.js
@@ -114,6 +114,13 @@ No data.
   }
 
   render() {
+    if (this.props.loading) {
+      return (
+        <div className="spinner-border" role="status">
+          <span className="sr-only">Loading...</span>
+        </div>
+      );
+    }
     return (
       <div>
         { this.renderPreferences(this.state) }
@@ -125,6 +132,7 @@ No data.
 UserPreferenceForm.propTypes = {
   email: PropTypes.string.isRequired,
   preferences: PropTypes.array.isRequired, // eslint-disable-line react/forbid-prop-types
+  loading: PropTypes.bool.isRequired,
 };
 
 export default UserPreferenceForm;

--- a/frontend/containers/MeetingRequest.js
+++ b/frontend/containers/MeetingRequest.js
@@ -5,7 +5,7 @@ class MeetingRequest extends Component {
   constructor(props) {
     super(props);
     this.handleSubmit = this.handleSubmit.bind(this);
-    this.state = { key: '', email: '' };
+    this.state = { key: '', email: '', loading: true };
   }
 
   componentDidMount() {
@@ -13,7 +13,7 @@ class MeetingRequest extends Component {
       axios.get(
         `/v1/meeting_request/${MeetingRequest.getMeetingSpecKey()}?email=${res.data.email}`,
       ).then((res2) => {
-        this.setState({ key: res2.data.key, email: res.data.email });
+        this.setState({ key: res2.data.key, email: res.data.email, loading: false });
       });
     });
   }
@@ -25,6 +25,7 @@ class MeetingRequest extends Component {
 
   handleSubmit() {
     const { key, email } = this.state;
+    this.setState({ loading: true });
     axios.post(
       '/v1/meeting_request/',
       {
@@ -33,22 +34,29 @@ class MeetingRequest extends Component {
         email,
       },
     ).then((res) => {
-      this.setState({ key: res.data.key, email });
+      this.setState({ key: res.data.key, email, loading: false });
     });
   }
 
   renderButton() {
-    const { key } = this.state;
-    if (key === '') {
-      return (
-        <button type="button" onClick={this.handleSubmit} className="btn btn-success btn-lg left30">
-          Ask for a Meeting this week.
-        </button>
-      );
+    const { key, loading } = this.state;
+
+    let btnMsg = 'Ask for a Meeting this week.';
+    let btnColor = 'btn-success';
+    if (key !== '') {
+      btnMsg = 'Remove request for a Meeting this week.';
+      btnColor = 'btn-danger';
     }
+
     return (
-      <button type="button" onClick={this.handleSubmit} className="btn btn-danger btn-lg left30">
-        Remove request for a Meeting this week.
+      <button type="button" onClick={this.handleSubmit} className={`btn ${btnColor} btn-lg left30`} disabled={loading}>
+        {loading && (
+          <>
+            <span className="spinner-border spinner-border-sm mr-2" role="status" aria-hidden="true" />
+            <span className="sr-only">Loading...</span>
+          </>
+        )}
+        {btnMsg}
       </button>
     );
   }

--- a/frontend/containers/UserPreferences.js
+++ b/frontend/containers/UserPreferences.js
@@ -19,6 +19,7 @@ class UserPreferences extends Component {
         },
       ],
       email: '',
+      loading: true,
     };
   }
 
@@ -26,17 +27,17 @@ class UserPreferences extends Component {
     axios.get('/email').then((res) => {
       axios.get(`/v1/user/preferences/?email=${res.data.email}`).then(
         (res2) => {
-          this.setState({ preferences: res2.data, email: res.data.email });
+          this.setState({ preferences: res2.data, email: res.data.email, loading: false });
         },
       );
     });
   }
 
   render() {
-    const { preferences, email } = this.state;
+    const { preferences, email, loading } = this.state;
     return (
       <div className="preferences">
-        <UserPreferenceForm preferences={preferences} email={email} />
+        <UserPreferenceForm preferences={preferences} email={email} loading={loading} />
       </div>
     );
   }


### PR DESCRIPTION
These pages aren't functional until they have finished loading, but there isn't anything indicating that they are loading. This causes confusion for users and leads to buttons not having any effect. On the meeting_request page if you click the button before the ajax requests finish then click the button doesn't do anything, but appears that it does. This leads to people thinking they requested a meeting when in reality nothing happened.