### PR TITLE
Pin devcontainers/cli to 0.50.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install devcontainer cli
-        run: npm install -g @devcontainers/cli
+        run: npm install -g @devcontainers/cli@0.50.0
       - name: Build and start container
         run: devcontainer up --workspace-folder .
       - name: Test developer workflow


### PR DESCRIPTION
There is an issue in 0.50.1 that has been fixed and not released yet. https://github.com/devcontainers/cli/issues/606