### PR TITLE
Start using dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,12 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      all dependencies:
-        pattern: "*"
+      all-dependencies:
+        patterns: "*"
   - package-ecosystem: "pip"
     directory: "/api"
     schedule:
       interval: "weekly"
     groups:
-      all dependencies:
-        pattern: "*"
+      all-dependencies:
+        patterns: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,13 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    groups:
+      all dependencies:
+        pattern: "*"
   - package-ecosystem: "pip"
     directory: "/api"
     schedule:
       interval: "weekly"
+    groups:
+      all dependencies:
+        pattern: "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,13 @@ updates:
       interval: "weekly"
     groups:
       all-dependencies:
-        patterns: "*"
+        patterns:
+          - "*"
   - package-ecosystem: "pip"
     directory: "/api"
     schedule:
       interval: "weekly"
     groups:
       all-dependencies:
-        patterns: "*"
+        patterns:
+          - "*"


### PR DESCRIPTION
You can now groups some or all of your dependency bumps into a single pull request. In beans we have a decent amount of dependencies and opening up a bunch of small pull requests is somewhat spammy and it seems like it would be easier to have one pull request for javascipt and another for python at a time.