### PR TITLE
Switch to devcontainers github action

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,4 +5,5 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
         | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
         && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
         && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-        && apt-get -y install --no-install-recommends fish google-cloud-cli vim
+        && apt-get -y install --no-install-recommends fish google-cloud-cli vim \
+        && groupadd --gid 999 docker

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,4 +5,5 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
         | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
         && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
         && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-        && apt-get -y install --no-install-recommends fish google-cloud-cli vim
+        && apt-get -y install --no-install-recommends fish google-cloud-cli vim \
+        && delgroup nvm

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,5 +5,4 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
         | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
         && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
         && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-        && apt-get -y install --no-install-recommends fish google-cloud-cli vim \
-        && delgroup nvm
+        && apt-get -y install --no-install-recommends fish google-cloud-cli vim

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 
   "forwardPorts": [5000, 8080],
 
-  "postCreateCommand": "python .devcontainer/configs_in_env.py load_from_env",
+  "postCreateCommand": "sudo delgroup docker && python .devcontainer/configs_in_env.py load_from_env",
 
   "remoteUser": "vscode",
   "features": {

--- a/.devcontainer/test_dev_env.sh
+++ b/.devcontainer/test_dev_env.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -exo pipefail
+id
 
 # This is the config we have in the wiki encoded by configs_from_env
 DEFAULT_CONFIG="H4sIAH9rQGQC/3WRUW+CMBSF/wrpiy9Ctz3yhtBsTKMG4WFZl6bAlXTiraPdzG\

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,9 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install devcontainer cli
-        run: npm install -g @devcontainers/cli
-      - name: Build and start container
-        run: devcontainer up --workspace-folder .
-      - name: Test developer workflow
-        run: devcontainer exec --workspace-folder . .devcontainer/test_dev_env.sh
+      - name: Build and run Dev Container tests
+        uses: devcontainers/ci@v0.3
+        with:
+          runCmd: .devcontainer/test_dev_env.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Check user ids
+        run: id
       - name: Build and run Dev Container tests
         uses: devcontainers/ci@v0.3
         with:


### PR DESCRIPTION
The devcontainer test started to fail randomly. It doesn't seem like it is our code, but a change in github actions or the cli. Switching to the devcontainers official github action could fix the issue and is more likely to get updated with fixes as github actions and the cli change.