### PR TITLE
Fix rendering of `Default Auto Opt In` value

### DIFF
--- a/frontend/containers/SubscriptionsList.js
+++ b/frontend/containers/SubscriptionsList.js
@@ -67,7 +67,7 @@ function SubscriptionList() {
               <td>{sub.location}</td>
               <td>{sub.office}</td>
               <td>{sub.size}</td>
-              <td>{sub.default_auto_opt_in}</td>
+              <td>{sub.default_auto_opt_in.toString()}</td>
               <td>{formatRules(sub.rules, sub.rule_logic)}</td>
               <td>{sub.timezone}</td>
               <td>{formatTimeSlots(sub.time_slots)}</td>


### PR DESCRIPTION
### Bug
The value (boolean) of `Default Auto Opt In` for each row doesn't get rendered

### Solution
[Apparently](https://github.com/TanStack/table/issues/799#issuecomment-364178057
) boolean values must be converted to a string to render 





