### PR TITLE
Add support for configuring auto opt-in with subscribe link

### DIFF
--- a/frontend/containers/Subscribe.js
+++ b/frontend/containers/Subscribe.js
@@ -9,6 +9,14 @@ const getSubscriptionId = () => {
   return path[path.length - 1];
 };
 
+const getAutoOptIn = () => {
+  const autoOptIn = window.location.search.get("auto_opt_in");
+  if (autoOptIn == null) {
+    return null;
+  }
+  return ["1", "t", "true", "y", "yes"].contains(autoOptIn);
+};
+
 function SubscribedMessage({ subscription, timeSlot, newPreference }) {
   let msg = "have been";
   if (!newPreference) {
@@ -67,6 +75,7 @@ function Subscribe() {
         axios
           .post(`/v1/user/preferences/subscribe/${getSubscriptionId()}`, {
             email: resEmail.data.email,
+            auto_opt_in: getAutoOptIn(),
           })
           .then((resSubscribe) => {
             setSubscribedSubscription(resSubscribe.data);


### PR DESCRIPTION
This adds support for configuring it in the api request and makes the frontend retrieve the option from the url params. This will either create a new subscription with the auto opt-in setting or update the existing subscription to use that auto opt-in setting.